### PR TITLE
【Rails】時刻と言語の日本対応 #24

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -23,10 +23,13 @@ gem "puma", "~> 5.0"
 gem "bootsnap", ">= 1.4.4", require: false
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
+gem "rack-cors"
+
 gem "devise"
+gem "devise-i18n"
 gem "devise_token_auth"
 gem "net-smtp", require: false
-gem "rack-cors"
+gem "rails-i18n"
 
 group :development, :test do
   gem "factory_bot"

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -75,6 +75,8 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    devise-i18n (1.10.2)
+      devise (>= 4.8.0)
     devise_token_auth (1.2.0)
       bcrypt (~> 3.0)
       devise (> 3.5.2, < 5)
@@ -151,6 +153,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.2)
       loofah (~> 2.3)
+    rails-i18n (7.0.3)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (6.1.6)
       actionpack (= 6.1.6)
       activesupport (= 6.1.6)
@@ -232,6 +237,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.4)
   byebug
   devise
+  devise-i18n
   devise_token_auth
   factory_bot
   faker
@@ -242,6 +248,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rack-cors
   rails (~> 6.1.6)
+  rails-i18n
   rspec-rails (~> 5.0.0)
   rubocop (~> 1.29)
   rubocop-performance

--- a/backend/config/application.rb
+++ b/backend/config/application.rb
@@ -29,7 +29,8 @@ module Divwork
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = "Tokyo"
+    config.i18n.default_locale = :ja
     # config.eager_load_paths << Rails.root.join("extras")
 
     # Only loads a smaller set of middleware suitable for API only apps.

--- a/backend/spec/models/user_spec.rb
+++ b/backend/spec/models/user_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe User, type: :model do
 
     it "エラーが発生すること" do
       user.valid?
-      expect(user.errors.messages[:email]).to include "can't be blank"
+      expect(user.errors.of_kind?(:email, :blank)).to be_truthy
     end
   end
 
@@ -23,7 +23,7 @@ RSpec.describe User, type: :model do
 
     it "エラーが発生すること" do
       user.valid?
-      expect(user.errors.messages[:password]).to include "can't be blank"
+      expect(user.errors.of_kind?(:password, :blank)).to be_truthy
     end
   end
 
@@ -33,7 +33,7 @@ RSpec.describe User, type: :model do
 
     it "エラーが発生すること" do
       user2.valid?
-      expect(user2.errors.messages[:email]).to include "has already been taken"
+      expect(user2.errors.of_kind?(:email, :taken)).to be_truthy
     end
   end
 end

--- a/backend/spec/models/user_spec.rb
+++ b/backend/spec/models/user_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe User, type: :model do
 
     it "エラーが発生すること" do
       user.valid?
-      expect(user.errors.of_kind?(:email, :blank)).to be_truthy
+      expect(user.errors).to be_of_kind(:email, :blank)
     end
   end
 
@@ -23,7 +23,7 @@ RSpec.describe User, type: :model do
 
     it "エラーが発生すること" do
       user.valid?
-      expect(user.errors.of_kind?(:password, :blank)).to be_truthy
+      expect(user.errors).to be_of_kind(:password, :blank)
     end
   end
 
@@ -33,7 +33,7 @@ RSpec.describe User, type: :model do
 
     it "エラーが発生すること" do
       user2.valid?
-      expect(user2.errors.of_kind?(:email, :taken)).to be_truthy
+      expect(user2.errors).to be_of_kind(:email, :taken)
     end
   end
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       - '3000:3000'
     depends_on:
       - db
+    tty: true
 
   frontend:
     build:
@@ -37,3 +38,4 @@ services:
       - ./frontend:/usr/src/app
     ports:
       - '3001:3000'
+    tty: true


### PR DESCRIPTION
### 目的
日本向けのアプリのため、時刻と言語を日本に設定する。

### 変更内容
- `timezone`を`Tokyo`に設定
- `locale`を`:ja`に設定
- RSpecのエラー文チェックを言語に依存しない形式に変更