### PR TITLE
feat: 未了/完了済みタスク抽出機能の実装 #33

### DIFF
--- a/backend/app/controllers/api/v1/users_controller.rb
+++ b/backend/app/controllers/api/v1/users_controller.rb
@@ -7,7 +7,10 @@ class Api::V1::UsersController < ApplicationController
     render json: { tasks: }, status: :ok
   end
 
-  def finished; end
+  def finished
+    tasks = @user.tasks.finished
+    render json: { tasks: }, status: :ok
+  end
 
   private
 

--- a/backend/app/controllers/api/v1/users_controller.rb
+++ b/backend/app/controllers/api/v1/users_controller.rb
@@ -3,7 +3,7 @@ class Api::V1::UsersController < ApplicationController
   before_action :set_user, only: [:show, :finished]
 
   def show
-    tasks = @user.tasks
+    tasks = @user.tasks.unfinished
     render json: { tasks: }, status: :ok
   end
 

--- a/backend/app/models/task.rb
+++ b/backend/app/models/task.rb
@@ -9,6 +9,6 @@ class Task < ApplicationRecord
   validates :priority, inclusion: { in: Task.priorities.keys }
   validates :is_done, inclusion: { in: [true, false] }
 
-  scope :unfinished, -> { where(is_done: false)}
+  scope :unfinished, -> { where(is_done: false) }
   scope :finished, -> { where(is_done: true) }
 end

--- a/backend/app/models/task.rb
+++ b/backend/app/models/task.rb
@@ -8,4 +8,6 @@ class Task < ApplicationRecord
   validates :deadline, presence: true
   validates :priority, inclusion: { in: Task.priorities.keys }
   validates :is_done, inclusion: { in: [true, false] }
+
+  scope :finished, -> { where(is_done: true) }
 end

--- a/backend/app/models/task.rb
+++ b/backend/app/models/task.rb
@@ -9,5 +9,6 @@ class Task < ApplicationRecord
   validates :priority, inclusion: { in: Task.priorities.keys }
   validates :is_done, inclusion: { in: [true, false] }
 
+  scope :unfinished, -> { where(is_done: false)}
   scope :finished, -> { where(is_done: true) }
 end

--- a/backend/spec/models/task_spec.rb
+++ b/backend/spec/models/task_spec.rb
@@ -56,4 +56,15 @@ RSpec.describe Task, type: :model do
       expect(task.errors).to be_of_kind(:user, :blank)
     end
   end
+
+  describe "scope finished" do
+    let!(:unfinished_task) { create(:task, is_done: false, user:) }
+    let!(:finished_task) { create(:task, is_done: true, user:) }
+
+    it "完了済みタスクを抽出すること" do
+      tasks = user.tasks.finished
+      expect(tasks).to include(finished_task)
+      expect(tasks).not_to include(unfinished_task)
+    end
+  end
 end

--- a/backend/spec/models/task_spec.rb
+++ b/backend/spec/models/task_spec.rb
@@ -57,9 +57,15 @@ RSpec.describe Task, type: :model do
     end
   end
 
-  describe "scope finished" do
+  describe "scope unfinished/finished" do
     let!(:unfinished_task) { create(:task, is_done: false, user:) }
     let!(:finished_task) { create(:task, is_done: true, user:) }
+
+    it "未了タスクを抽出すること" do
+      tasks = user.tasks.unfinished
+      expect(tasks).to include(unfinished_task)
+      expect(tasks).not_to include(finished_task)
+    end
 
     it "完了済みタスクを抽出すること" do
       tasks = user.tasks.finished

--- a/backend/spec/requests/api/v1/users_spec.rb
+++ b/backend/spec/requests/api/v1/users_spec.rb
@@ -8,24 +8,31 @@ RSpec.describe "Api::V1::Users", type: :request do
   let(:headers) { user.create_new_auth_token }
 
   describe "GET /" do
-    it "ユーザーのタスク一覧表示に成功すること" do
-      get "/api/v1/users/#{user.id}", headers: headers
+    before do
+      get "/api/v1/users/#{user.id}", headers:
+    end
+
+    it "ユーザーの未了タスクの情報取得に成功すること" do
       expect(response).to have_http_status(:ok)
-      expect(response.body).to include(unfinished_task.to_json && finished_task.to_json)
+      expect(response.body).to include(unfinished_task.to_json)
+    end
+
+    it "完了済みタスクが含まれていないこと" do
+      expect(response.body).not_to include(finished_task.to_json)
     end
   end
 
   describe "GET /finished" do
     before do
-      get "/api/v1/users/#{user.id}/finished", headers: headers
+      get "/api/v1/users/#{user.id}/finished", headers:
     end
 
-    it "ユーザーの完了済みタスク表示に成功すること" do
+    it "ユーザーの完了済みタスクの情報取得に成功すること" do
       expect(response).to have_http_status(:ok)
       expect(response.body).to include(finished_task.to_json)
     end
 
-    it "未了のタスクが表示されていないこと" do
+    it "未了のタスクが含まれていないこと" do
       expect(response.body).not_to include(unfinished_task.to_json)
     end
   end

--- a/backend/spec/requests/api/v1/users_spec.rb
+++ b/backend/spec/requests/api/v1/users_spec.rb
@@ -3,15 +3,30 @@ require "rails_helper"
 RSpec.describe "Api::V1::Users", type: :request do
   let(:team) { create(:team) }
   let(:user) { create(:user, team:) }
-  let!(:task_a) { create(:task, user:) }
-  let!(:task_b) { create(:task, user:) }
+  let!(:unfinished_task) { create(:task, is_done: false, user:) }
+  let!(:finished_task) { create(:task, is_done: true, user:) }
   let(:headers) { user.create_new_auth_token }
 
   describe "GET /" do
     it "ユーザーのタスク一覧表示に成功すること" do
       get "/api/v1/users/#{user.id}", headers: headers
       expect(response).to have_http_status(:ok)
-      expect(response.body).to include(task_a.to_json && task_b.to_json)
+      expect(response.body).to include(unfinished_task.to_json && finished_task.to_json)
+    end
+  end
+
+  describe "GET /finished" do
+    before do
+      get "/api/v1/users/#{user.id}/finished", headers: headers
+    end
+
+    it "ユーザーの完了済みタスク表示に成功すること" do
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(finished_task.to_json)
+    end
+
+    it "未了のタスクが表示されていないこと" do
+      expect(response.body).not_to include(unfinished_task.to_json)
     end
   end
 end


### PR DESCRIPTION
### 目的
未了タスク、完了済みタスクを別ページで表示させるため。

### 変更内容
- Taskモデル内で`unfinished` `finished` scopeを定義
- `users#show`で未了タスクを抽出するよう修正
- `users#finished`で完了済みタスクを抽出するよう定義
- model, request specを追加