### PR TITLE
feat: タスク分担コメント機能を追加 #37

### DIFF
--- a/backend/.rubocop.yml
+++ b/backend/.rubocop.yml
@@ -55,3 +55,10 @@ Style/GuardClause:
 
 Style/IfUnlessModifier:
   Enabled: false
+
+Metrics/MethodLength:
+  CountComments: false
+  Max: 30
+
+RSpec/ExampleLength:
+  Enabled: false

--- a/backend/app/controllers/api/v1/divisions_controller.rb
+++ b/backend/app/controllers/api/v1/divisions_controller.rb
@@ -23,6 +23,6 @@ class Api::V1::DivisionsController < ApplicationController
   private
 
   def task_params
-    params.permit(:title, :content, :deadline, :priority, :is_done, :user_id, :parent_id)
+    params.permit(:title, :description, :deadline, :priority, :is_done, :user_id, :parent_id)
   end
 end

--- a/backend/app/controllers/api/v1/divisions_controller.rb
+++ b/backend/app/controllers/api/v1/divisions_controller.rb
@@ -12,7 +12,11 @@ class Api::V1::DivisionsController < ApplicationController
     new_task = Task.new(task_params)
     new_task.save!
 
-    division = Division.new(user_id: current_api_v1_user.id, task_id: new_task.id)
+    division = Division.new(
+      user_id: current_api_v1_user.id,
+      task_id: new_task.id,
+      comment: division_params[:comment]
+    )
     division.save!
 
     render json: { task: new_task, division: }, status: :ok
@@ -23,6 +27,10 @@ class Api::V1::DivisionsController < ApplicationController
   private
 
   def task_params
-    params.permit(:title, :description, :deadline, :priority, :is_done, :user_id, :parent_id)
+    params.require(:task).permit(:title, :description, :deadline, :priority, :is_done, :user_id, :parent_id)
+  end
+
+  def division_params
+    params.require(:division).permit(:comment)
   end
 end

--- a/backend/app/controllers/api/v1/tasks_controller.rb
+++ b/backend/app/controllers/api/v1/tasks_controller.rb
@@ -45,6 +45,6 @@ class Api::V1::TasksController < ApplicationController
   end
 
   def task_params
-    params.require(:task).permit(:title, :content, :deadline, :priority, :is_done, :user_id)
+    params.require(:task).permit(:title, :description, :deadline, :priority, :is_done, :user_id)
   end
 end

--- a/backend/app/models/division.rb
+++ b/backend/app/models/division.rb
@@ -1,4 +1,6 @@
 class Division < ApplicationRecord
   belongs_to :user
   belongs_to :task
+
+  validates :comment, length: { maximum: 100 }
 end

--- a/backend/app/models/task.rb
+++ b/backend/app/models/task.rb
@@ -7,7 +7,7 @@ class Task < ApplicationRecord
   enum priority: { low: 0, medium: 1, high: 2 }
 
   validates :title, presence: true, length: { maximum: 50 }
-  validates :content, length: { maximum: 400 }
+  validates :description, length: { maximum: 400 }
   validates :deadline, presence: true
   validates :priority, inclusion: { in: Task.priorities.keys }
   validates :is_done, inclusion: { in: [true, false] }

--- a/backend/config/locales/ja.yml
+++ b/backend/config/locales/ja.yml
@@ -16,3 +16,5 @@ ja:
         deadline: 納期
         priority: 優先度
         is_done: 完了済み
+      division:
+        comment: コメント

--- a/backend/config/locales/ja.yml
+++ b/backend/config/locales/ja.yml
@@ -12,7 +12,7 @@ ja:
         name: ユーザー名
       task:
         title: タイトル
-        content: 内容
+        description: 詳細
         deadline: 納期
         priority: 優先度
         is_done: 完了済み

--- a/backend/db/migrate/20220613043918_add_column_comment_to_divisions.rb
+++ b/backend/db/migrate/20220613043918_add_column_comment_to_divisions.rb
@@ -1,0 +1,5 @@
+class AddColumnCommentToDivisions < ActiveRecord::Migration[6.1]
+  def change
+    add_column :divisions, :comment, :string
+  end
+end

--- a/backend/db/migrate/20220613051133_change_column_description_to_tasks.rb
+++ b/backend/db/migrate/20220613051133_change_column_description_to_tasks.rb
@@ -1,0 +1,5 @@
+class ChangeColumnDescriptionToTasks < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :tasks, :content, :description
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_13_043918) do
+ActiveRecord::Schema.define(version: 2022_06_13_051133) do
 
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -52,7 +52,7 @@ ActiveRecord::Schema.define(version: 2022_06_13_043918) do
 
   create_table "tasks", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "title", null: false
-    t.text "content"
+    t.text "description"
     t.datetime "deadline", null: false
     t.integer "priority", default: 0, null: false
     t.boolean "is_done", default: false, null: false

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_09_124047) do
+ActiveRecord::Schema.define(version: 2022_06_13_043918) do
 
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -45,6 +45,7 @@ ActiveRecord::Schema.define(version: 2022_06_09_124047) do
     t.bigint "task_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "comment"
     t.index ["task_id"], name: "index_divisions_on_task_id"
     t.index ["user_id"], name: "index_divisions_on_user_id"
   end

--- a/backend/db/seeds.rb
+++ b/backend/db/seeds.rb
@@ -13,7 +13,7 @@
     3.times do |l|
       user.tasks.create!(
         title: Faker::Job.title,
-        content: Faker::Books::Lovecraft.sentence,
+        description: Faker::Books::Lovecraft.sentence,
         deadline: Faker::Time.between(from: DateTime.now, to: DateTime.now + 7, format: :long),
         priority: rand(0..2),
         is_done: false

--- a/backend/spec/factories/divisions.rb
+++ b/backend/spec/factories/divisions.rb
@@ -1,3 +1,5 @@
 FactoryBot.define do
-  factory :division
+  factory :division do
+    comment { Faker::Books::Lovecraft.sentence }
+  end
 end

--- a/backend/spec/factories/tasks.rb
+++ b/backend/spec/factories/tasks.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :task do
     title { Faker::Job.title }
-    content { Faker::Books::Lovecraft.sentence }
+    description { Faker::Books::Lovecraft.sentence }
     deadline { Faker::Time.between(from: DateTime.now, to: DateTime.now + 7, format: :long) }
     priority { rand(0..2) }
     is_done { false }


### PR DESCRIPTION
### 目的
タスク分担時にコメントを添付出来るようにするため。

### 変更内容
- Divisionテーブルにcommentカラムを追加
- Divisionsコントローラの修正
- request specの修正