### PR TITLE
feat: タスク新規作成、編集ページの作成 #68

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import UsersShow from "./pages/UsersShow";
 import TasksShow from "./pages/TasksShow";
 import TasksNew from "./pages/TasksNew";
 import DivisionsNew from "./pages/DivisionsNew";
+import TasksEdit from "./pages/TasksEdit";
 
 const App: React.FC = () => {
   return (
@@ -25,6 +26,7 @@ const App: React.FC = () => {
           <Route path="users/:id" element={<UsersShow />} />
           <Route path="/tasks/new" element={<TasksNew />} />
           <Route path="/tasks/:id" element={<TasksShow />} />
+          <Route path="/tasks/:id/edit" element={<TasksEdit />} />
           <Route path="/tasks/:id/divisions/new" element={<DivisionsNew />} />
         </Routes>
       </AuthProvider>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,14 +1,15 @@
 import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { AuthProvider } from "./providers/AuthProvider";
+import Home from "./pages/Home";
+import Header from "./components/Header";
+import SignUp from "./pages/SignUp";
 import SignIn from "./pages/SignIn";
 import TeamsSelect from "./pages/TeamsSelect";
 import TeamsShow from "./pages/TeamsShow";
 import UsersShow from "./pages/UsersShow";
 import TasksShow from "./pages/TasksShow";
+import TasksNew from "./pages/TasksNew";
 import DivisionsNew from "./pages/DivisionsNew";
-import SignUp from "./pages/SignUp";
-import Header from "./components/Header";
-import Home from "./pages/Home";
-import { AuthProvider } from "./providers/AuthProvider";
 
 const App: React.FC = () => {
   return (
@@ -22,8 +23,9 @@ const App: React.FC = () => {
           <Route path="/sign_in" element={<SignIn />} />
           <Route path="/teams/:id" element={<TeamsShow />} />
           <Route path="users/:id" element={<UsersShow />} />
-          <Route path="tasks/:id" element={<TasksShow />} />
-          <Route path="tasks/:id/divisions/new" element={<DivisionsNew />} />
+          <Route path="/tasks/new" element={<TasksNew />} />
+          <Route path="/tasks/:id" element={<TasksShow />} />
+          <Route path="/tasks/:id/divisions/new" element={<DivisionsNew />} />
         </Routes>
       </AuthProvider>
     </BrowserRouter>

--- a/frontend/src/hooks/useFetchTask.ts
+++ b/frontend/src/hooks/useFetchTask.ts
@@ -28,7 +28,7 @@ export const useFetchTask = () => {
       .catch((err) => {
         console.log(err);
       });
-  }, []);
+  }, [data]);
 
   return data;
 };

--- a/frontend/src/hooks/useFetchTask.ts
+++ b/frontend/src/hooks/useFetchTask.ts
@@ -1,0 +1,34 @@
+import { AxiosRequestConfig, AxiosResponse } from "axios";
+import Cookies from "js-cookie";
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import { Task, TasksResponse } from "../types";
+import { axiosInstance } from "../utils/axios";
+
+export const useFetchTask = () => {
+  const [data, setData] = useState<Task>();
+  const params = useParams<{ id: string }>();
+
+  const options: AxiosRequestConfig = {
+    url: `/tasks/${params.id}`,
+    method: "GET",
+    headers: {
+      "access-token": Cookies.get("_access_token") || "",
+      client: Cookies.get("_client") || "",
+      uid: Cookies.get("_uid") || "",
+    },
+  };
+
+  useEffect(() => {
+    axiosInstance(options)
+      .then((res: AxiosResponse<TasksResponse>) => {
+        console.log(res);
+        setData(res?.data.task);
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  }, []);
+
+  return data;
+};

--- a/frontend/src/pages/DivisionsNew.tsx
+++ b/frontend/src/pages/DivisionsNew.tsx
@@ -2,14 +2,14 @@ import { AxiosRequestConfig, AxiosResponse } from "axios";
 import Cookies from "js-cookie";
 import { ChangeEvent, FC, useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import { newTask, TasksResponse, DivisionsCreateResponse } from "../types";
+import { divisionTask, TasksResponse, DivisionsCreateResponse } from "../types";
 import { axiosInstance } from "../utils/axios";
 
 const DivisionsNew: FC = () => {
   const params = useParams<{ id: string }>();
   const navigate = useNavigate();
 
-  const [task, setTask] = useState<newTask>({
+  const [task, setTask] = useState<divisionTask>({
     title: "",
     description: "",
     deadline: "",

--- a/frontend/src/pages/TasksEdit.tsx
+++ b/frontend/src/pages/TasksEdit.tsx
@@ -1,10 +1,11 @@
-import { ChangeEvent, FC, useContext, useEffect, useState } from "react";
+import { ChangeEvent, FC, useContext, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import Cookies from "js-cookie";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { axiosInstance } from "../utils/axios";
 import { TasksResponse, editTask } from "../types";
 import { AuthContext } from "../providers/AuthProvider";
+import { useFetchTask } from "../hooks/useFetchTask";
 
 const TasksEdit: FC = () => {
   const { currentUser } = useContext(AuthContext);
@@ -26,28 +27,10 @@ const TasksEdit: FC = () => {
     setTask({ ...task, [name]: value });
   };
 
+  const data = useFetchTask();
+  if (data) setTask(data);
+
   const params = useParams<{ id: string }>();
-
-  const options: AxiosRequestConfig = {
-    url: `/tasks/${params.id}`,
-    method: "GET",
-    headers: {
-      "access-token": Cookies.get("_access_token") || "",
-      client: Cookies.get("_client") || "",
-      uid: Cookies.get("_uid") || "",
-    },
-  };
-
-  useEffect(() => {
-    axiosInstance(options)
-      .then((res: AxiosResponse<TasksResponse>) => {
-        console.log(res);
-        setTask(res?.data.task);
-      })
-      .catch((err) => {
-        console.log(err);
-      });
-  }, []);
 
   const handleTasksUpdate = () => {
     const updateOptions: AxiosRequestConfig = {
@@ -79,7 +62,11 @@ const TasksEdit: FC = () => {
       <div>
         <label>
           タイトル
-          <input name="title" value={task.title} onChange={handleInputChange} />
+          <input
+            name="title"
+            value={task?.title}
+            onChange={handleInputChange}
+          />
         </label>
       </div>
       <br />
@@ -88,7 +75,7 @@ const TasksEdit: FC = () => {
           詳細
           <textarea
             name="description"
-            value={task.description}
+            value={task?.description}
             onChange={handleInputChange}
           />
         </label>
@@ -100,7 +87,7 @@ const TasksEdit: FC = () => {
           <input
             type="text"
             name="deadline"
-            value={task.deadline}
+            value={task?.deadline}
             onChange={handleInputChange}
           />
         </label>
@@ -111,7 +98,7 @@ const TasksEdit: FC = () => {
           優先度
           <input
             name="priority"
-            value={task.priority}
+            value={task?.priority}
             onChange={handleInputChange}
           />
         </label>

--- a/frontend/src/pages/TasksEdit.tsx
+++ b/frontend/src/pages/TasksEdit.tsx
@@ -1,0 +1,127 @@
+import { ChangeEvent, FC, useContext, useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import Cookies from "js-cookie";
+import { AxiosRequestConfig, AxiosResponse } from "axios";
+import { axiosInstance } from "../utils/axios";
+import { TasksResponse, editTask } from "../types";
+import { AuthContext } from "../providers/AuthProvider";
+
+const TasksEdit: FC = () => {
+  const { currentUser } = useContext(AuthContext);
+  const navigate = useNavigate();
+
+  const [task, setTask] = useState<editTask>({
+    title: "",
+    description: "",
+    deadline: "",
+    priority: "",
+    is_done: false,
+    user_id: 0,
+  });
+
+  const handleInputChange = (
+    event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    const { name, value } = event.target;
+    setTask({ ...task, [name]: value });
+  };
+
+  const params = useParams<{ id: string }>();
+
+  const options: AxiosRequestConfig = {
+    url: `/tasks/${params.id}`,
+    method: "GET",
+    headers: {
+      "access-token": Cookies.get("_access_token") || "",
+      client: Cookies.get("_client") || "",
+      uid: Cookies.get("_uid") || "",
+    },
+  };
+
+  useEffect(() => {
+    axiosInstance(options)
+      .then((res: AxiosResponse<TasksResponse>) => {
+        console.log(res);
+        setTask(res?.data.task);
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  }, []);
+
+  const handleTasksUpdate = () => {
+    const updateOptions: AxiosRequestConfig = {
+      url: `/tasks/${params.id}`,
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        "access-token": Cookies.get("_access_token") || "",
+        client: Cookies.get("_client") || "",
+        uid: Cookies.get("_uid") || "",
+      },
+      data: task,
+    };
+
+    axiosInstance(updateOptions)
+      .then((res: AxiosResponse<TasksResponse>) => {
+        console.log(res);
+
+        if (res.status === 200) {
+          navigate(`/users/${currentUser?.id}`, { replace: false });
+        }
+      })
+      .catch((err) => console.log(err));
+  };
+
+  return (
+    <div>
+      <h1>Tasks#Edit</h1>
+      <div>
+        <label>
+          タイトル
+          <input name="title" value={task.title} onChange={handleInputChange} />
+        </label>
+      </div>
+      <br />
+      <div>
+        <label>
+          詳細
+          <textarea
+            name="description"
+            value={task.description}
+            onChange={handleInputChange}
+          />
+        </label>
+      </div>
+      <br />
+      <div>
+        <label>
+          納期
+          <input
+            type="text"
+            name="deadline"
+            value={task.deadline}
+            onChange={handleInputChange}
+          />
+        </label>
+      </div>
+      <br />
+      <div>
+        <label>
+          優先度
+          <input
+            name="priority"
+            value={task.priority}
+            onChange={handleInputChange}
+          />
+        </label>
+      </div>
+      <br />
+      <button type="submit" onClick={handleTasksUpdate}>
+        更新する
+      </button>
+    </div>
+  );
+};
+
+export default TasksEdit;

--- a/frontend/src/pages/TasksNew.tsx
+++ b/frontend/src/pages/TasksNew.tsx
@@ -16,7 +16,6 @@ const TasksNew: FC = () => {
     deadline: "",
     priority: "",
     is_done: false,
-    user_id: 0,
   });
 
   const handleInputChange = (
@@ -36,14 +35,21 @@ const TasksNew: FC = () => {
         client: Cookies.get("_client") || "",
         uid: Cookies.get("_uid") || "",
       },
-      data: task,
+      data: {
+        title: task.title,
+        description: task.description,
+        deadline: task.deadline,
+        priority: task.priority,
+        is_done: task.is_done,
+        user_id: currentUser?.id,
+      },
     };
 
     axiosInstance(options)
       .then((res: AxiosResponse<TasksResponse>) => {
         console.log(res);
 
-        if (res.status === 200) {
+        if (res.status === 201) {
           navigate(`/users/${currentUser?.id}`, { replace: false });
         }
       })
@@ -52,7 +58,7 @@ const TasksNew: FC = () => {
 
   return (
     <div>
-      <h1>Divisions#New</h1>
+      <h1>Tasks#New</h1>
       <div>
         <label>
           タイトル
@@ -89,17 +95,6 @@ const TasksNew: FC = () => {
           <input
             name="priority"
             value={task.priority}
-            onChange={handleInputChange}
-          />
-        </label>
-      </div>
-      <br />
-      <div>
-        <label>
-          ユーザー
-          <input
-            name="user_id"
-            value={task.user_id}
             onChange={handleInputChange}
           />
         </label>

--- a/frontend/src/pages/TasksNew.tsx
+++ b/frontend/src/pages/TasksNew.tsx
@@ -1,0 +1,115 @@
+import { ChangeEvent, FC, useContext, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import Cookies from "js-cookie";
+import { AxiosRequestConfig, AxiosResponse } from "axios";
+import { axiosInstance } from "../utils/axios";
+import { TasksResponse, newTask } from "../types";
+import { AuthContext } from "../providers/AuthProvider";
+
+const TasksNew: FC = () => {
+  const { currentUser } = useContext(AuthContext);
+  const navigate = useNavigate();
+
+  const [task, setTask] = useState<newTask>({
+    title: "",
+    description: "",
+    deadline: "",
+    priority: "",
+    is_done: false,
+    user_id: 0,
+  });
+
+  const handleInputChange = (
+    event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    const { name, value } = event.target;
+    setTask({ ...task, [name]: value });
+  };
+
+  const handleTasksCreate = () => {
+    const options: AxiosRequestConfig = {
+      url: "/tasks",
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "access-token": Cookies.get("_access_token") || "",
+        client: Cookies.get("_client") || "",
+        uid: Cookies.get("_uid") || "",
+      },
+      data: task,
+    };
+
+    axiosInstance(options)
+      .then((res: AxiosResponse<TasksResponse>) => {
+        console.log(res);
+
+        if (res.status === 200) {
+          navigate(`/users/${currentUser?.id}`, { replace: false });
+        }
+      })
+      .catch((err) => console.log(err));
+  };
+
+  return (
+    <div>
+      <h1>Divisions#New</h1>
+      <div>
+        <label>
+          タイトル
+          <input name="title" value={task.title} onChange={handleInputChange} />
+        </label>
+      </div>
+      <br />
+      <div>
+        <label>
+          詳細
+          <textarea
+            name="description"
+            value={task.description}
+            onChange={handleInputChange}
+          />
+        </label>
+      </div>
+      <br />
+      <div>
+        <label>
+          納期
+          <input
+            type="text"
+            name="deadline"
+            value={task.deadline}
+            onChange={handleInputChange}
+          />
+        </label>
+      </div>
+      <br />
+      <div>
+        <label>
+          優先度
+          <input
+            name="priority"
+            value={task.priority}
+            onChange={handleInputChange}
+          />
+        </label>
+      </div>
+      <br />
+      <div>
+        <label>
+          ユーザー
+          <input
+            name="user_id"
+            value={task.user_id}
+            onChange={handleInputChange}
+          />
+        </label>
+      </div>
+      <br />
+      <button type="submit" onClick={handleTasksCreate}>
+        作成する
+      </button>
+    </div>
+  );
+};
+
+export default TasksNew;

--- a/frontend/src/pages/TasksShow.tsx
+++ b/frontend/src/pages/TasksShow.tsx
@@ -31,7 +31,7 @@ const TasksShow: FC = () => {
       </div>
       {task?.user_id === currentUser?.id && (
         <div>
-          <Link to="/tasks/edit">
+          <Link to={`/tasks/${task?.id}/edit`}>
             <button type="button">編集</button>
           </Link>
         </div>

--- a/frontend/src/pages/TasksShow.tsx
+++ b/frontend/src/pages/TasksShow.tsx
@@ -1,15 +1,42 @@
-import { FC } from "react";
+import { FC, useContext } from "react";
 import { Link } from "react-router-dom";
 import { useFetchTask } from "../hooks/useFetchTask";
+import { AuthContext } from "../providers/AuthProvider";
 
 const TasksShow: FC = () => {
   const task = useFetchTask();
+  const { currentUser } = useContext(AuthContext);
 
   return (
     <div>
       <h1>Tasks#Show</h1>
-      <h2>{task?.title}</h2>
-      <h3>{task?.description}</h3>
+      <div>
+        <h2>{task?.title}</h2>
+      </div>
+      <div>
+        <h4>詳細</h4>
+        <p>{task?.description}</p>
+      </div>
+      <div>
+        <h4>納期</h4>
+        <p>{task?.deadline}</p>
+      </div>
+      <div>
+        <h4>優先度</h4>
+        <p>{task?.priority}</p>
+      </div>
+      <div>
+        <h4>完了フラグ</h4>
+        <p>{task?.is_done.toString()}</p>
+      </div>
+      {task?.user_id === currentUser?.id && (
+        <div>
+          <Link to="/tasks/edit">
+            <button type="button">編集</button>
+          </Link>
+        </div>
+      )}
+      <br />
       <div>
         <Link to={`/tasks/${task?.id}/divisions/new`}>
           <button type="button">分担する</button>

--- a/frontend/src/pages/TasksShow.tsx
+++ b/frontend/src/pages/TasksShow.tsx
@@ -1,34 +1,9 @@
-import { FC, useEffect, useState } from "react";
-import { useParams, Link } from "react-router-dom";
-import Cookies from "js-cookie";
-import { AxiosRequestConfig, AxiosResponse } from "axios";
-import { axiosInstance } from "../utils/axios";
-import { TasksResponse, Task } from "../types";
+import { FC } from "react";
+import { Link } from "react-router-dom";
+import { useFetchTask } from "../hooks/useFetchTask";
 
 const TasksShow: FC = () => {
-  const [task, setTask] = useState<Task>();
-  const params = useParams<{ id: string }>();
-
-  const options: AxiosRequestConfig = {
-    url: `/tasks/${params.id}`,
-    method: "GET",
-    headers: {
-      "access-token": Cookies.get("_access_token") || "",
-      client: Cookies.get("_client") || "",
-      uid: Cookies.get("_uid") || "",
-    },
-  };
-
-  useEffect(() => {
-    axiosInstance(options)
-      .then((res: AxiosResponse<TasksResponse>) => {
-        console.log(res);
-        setTask(res?.data.task);
-      })
-      .catch((err) => {
-        console.log(err);
-      });
-  }, []);
+  const task = useFetchTask();
 
   return (
     <div>

--- a/frontend/src/pages/UsersShow.tsx
+++ b/frontend/src/pages/UsersShow.tsx
@@ -1,13 +1,16 @@
-import { useState, useEffect, FC } from "react";
+import { useState, useEffect, FC, useContext } from "react";
 import { useParams, Link } from "react-router-dom";
 import Cookies from "js-cookie";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { axiosInstance } from "../utils/axios";
 import { User, Task, UsersShowResponse } from "../types";
+import { AuthContext } from "../providers/AuthProvider";
 
 const UsersShow: FC = () => {
   const [user, setUser] = useState<User>();
   const [tasks, setTasks] = useState<Task[]>([]);
+
+  const { currentUser } = useContext(AuthContext);
 
   const params = useParams<{ id: string }>();
 
@@ -37,6 +40,13 @@ const UsersShow: FC = () => {
     <div>
       <h1>Users#Show</h1>
       <h2>{user?.name}</h2>
+      {user?.id === currentUser?.id && (
+        <div>
+          <Link to="/tasks/new">
+            <button type="button">新規作成</button>
+          </Link>
+        </div>
+      )}
       <div>
         <ul>
           {tasks?.map((task) => (

--- a/frontend/src/tests/TasksNew.test.tsx
+++ b/frontend/src/tests/TasksNew.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from "@testing-library/react";
+import renderer from "react-test-renderer"; // eslint-disable-line import/no-extraneous-dependencies
+import { BrowserRouter } from "react-router-dom";
+import TasksNew from "../pages/TasksNew";
+
+describe("TasksNew", () => {
+  test("'タイトル'ラベルが表示されていること", () => {
+    render(
+      <BrowserRouter>
+        <TasksNew />
+      </BrowserRouter>
+    );
+    const labelElement = screen.getByLabelText("タイトル");
+    expect(labelElement).toBeInTheDocument();
+  });
+
+  test("スナップショット", () => {
+    const tree = renderer
+      .create(
+        <BrowserRouter>
+          <TasksNew />
+        </BrowserRouter>
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/frontend/src/tests/__snapshots__/TasksNew.test.tsx.snap
+++ b/frontend/src/tests/__snapshots__/TasksNew.test.tsx.snap
@@ -1,0 +1,60 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TasksNew スナップショット 1`] = `
+<div>
+  <h1>
+    Tasks#New
+  </h1>
+  <div>
+    <label>
+      タイトル
+      <input
+        name="title"
+        onChange={[Function]}
+        value=""
+      />
+    </label>
+  </div>
+  <br />
+  <div>
+    <label>
+      詳細
+      <textarea
+        name="description"
+        onChange={[Function]}
+        value=""
+      />
+    </label>
+  </div>
+  <br />
+  <div>
+    <label>
+      納期
+      <input
+        name="deadline"
+        onChange={[Function]}
+        type="text"
+        value=""
+      />
+    </label>
+  </div>
+  <br />
+  <div>
+    <label>
+      優先度
+      <input
+        name="priority"
+        onChange={[Function]}
+        value=""
+      />
+    </label>
+  </div>
+  <br />
+  <button
+    onClick={[Function]}
+    type="submit"
+  >
+    作成する
+  </button>
+</div>
+`;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -49,6 +49,15 @@ export type newTask = {
   priority: string;
   is_done: boolean;
   user_id: number;
+};
+
+export type divisionTask = {
+  title: string;
+  description: string;
+  deadline: string;
+  priority: string;
+  is_done: boolean;
+  user_id: number;
   parent_id: number;
 };
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -48,7 +48,6 @@ export type newTask = {
   deadline: string;
   priority: string;
   is_done: boolean;
-  user_id: number;
 };
 
 export type divisionTask = {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -50,6 +50,15 @@ export type newTask = {
   is_done: boolean;
 };
 
+export type editTask = {
+  title: string;
+  description: string;
+  deadline: string;
+  priority: string;
+  is_done: boolean;
+  user_id: number;
+};
+
 export type divisionTask = {
   title: string;
   description: string;


### PR DESCRIPTION
### 目的
backendと連携してタスク新規作成、編集操作が出来るようにする。

### 変更内容
- TasksNewページの作成
- UsersShowページに新規作成ボタンを追加
- TasksEditページの作成
- TasksShowページに編集ボタンを追加