### PR TITLE
fix: dovenvをグローバル環境に変更

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -29,11 +29,11 @@ gem "aws-sdk-s3", require: false
 gem "devise"
 gem "devise-i18n"
 gem "devise_token_auth"
+gem "dotenv-rails"
 gem "net-smtp", require: false
 gem "rails-i18n"
 
 group :development, :test do
-  gem "dotenv-rails"
   gem "factory_bot"
   gem "faker"
   gem "rspec-rails", "~> 5.0.0"


### PR DESCRIPTION
### 目的
.envを本番環境でも読み込めるようにするため

### 変更内容
- `Gemfile`内の`gem "dotenv-rails"`をグループ外に移動