### PR TITLE
fix: fakerをグローバル環境に変更

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -30,12 +30,12 @@ gem "devise"
 gem "devise-i18n"
 gem "devise_token_auth"
 gem "dotenv-rails"
+gem "faker"
 gem "net-smtp", require: false
 gem "rails-i18n"
 
 group :development, :test do
   gem "factory_bot"
-  gem "faker"
   gem "rspec-rails", "~> 5.0.0"
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]


### PR DESCRIPTION
### 目的
fakerを本番環境DBのseedで使用するため。

### 変更内容
- `Gemfile`の`gem "faker"`をグループ外に移動