### PR TITLE
fix: start_urlを/に変更

### DIFF
--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -18,7 +18,7 @@
       "sizes": "512x512"
     }
   ],
-  "start_url": ".",
+  "start_url": "/",
   "display": "standalone",
   "theme_color": "#000000",
   "background_color": "#ffffff"


### PR DESCRIPTION
### 変更理由
構文エラー解消のため。

### 変更内容
- `manifest.json`内の`"start_url"`を`"/"`に変更