### PR TITLE
feat: Home, Headerにスタイルを当てる #103

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,7 @@
     "@babel/runtime": "^7.18.9",
     "@emotion/react": "^11.9.3",
     "@emotion/styled": "^11.9.3",
+    "@fontsource/roboto": "^4.5.7",
     "@mui/material": "^5.9.0",
     "@mui/x-date-pickers": "^5.0.0-beta.1",
     "@testing-library/react": "^13.0.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,10 @@ import TasksShow from "./pages/TasksShow";
 import TasksNew from "./pages/TasksNew";
 import DivisionsNew from "./pages/DivisionsNew";
 import TasksEdit from "./pages/TasksEdit";
+import "@fontsource/roboto/300.css";
+import "@fontsource/roboto/400.css";
+import "@fontsource/roboto/500.css";
+import "@fontsource/roboto/700.css";
 
 const App: React.FC = () => {
   const global = css`

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { css, Global } from "@emotion/react";
+import { Box } from "@mui/material";
 import { AuthProvider } from "./providers/AuthProvider";
 import Home from "./pages/Home";
 import Header from "./components/Header";
@@ -29,18 +30,20 @@ const App: React.FC = () => {
       <Global styles={global} />
       <AuthProvider>
         <Header />
-        <Routes>
-          <Route path="/" element={<Home />} />
-          <Route path="/sign_up/teams/select" element={<TeamsSelect />} />
-          <Route path="/sign_up" element={<SignUp />} />
-          <Route path="/sign_in" element={<SignIn />} />
-          <Route path="/teams/:id" element={<TeamsShow />} />
-          <Route path="users/:id" element={<UsersShow />} />
-          <Route path="/tasks/new" element={<TasksNew />} />
-          <Route path="/tasks/:id" element={<TasksShow />} />
-          <Route path="/tasks/:id/edit" element={<TasksEdit />} />
-          <Route path="/tasks/:id/divisions/new" element={<DivisionsNew />} />
-        </Routes>
+        <Box m={2} pt={3}>
+          <Routes>
+            <Route path="/" element={<Home />} />
+            <Route path="/sign_up/teams/select" element={<TeamsSelect />} />
+            <Route path="/sign_up" element={<SignUp />} />
+            <Route path="/sign_in" element={<SignIn />} />
+            <Route path="/teams/:id" element={<TeamsShow />} />
+            <Route path="users/:id" element={<UsersShow />} />
+            <Route path="/tasks/new" element={<TasksNew />} />
+            <Route path="/tasks/:id" element={<TasksShow />} />
+            <Route path="/tasks/:id/edit" element={<TasksEdit />} />
+            <Route path="/tasks/:id/divisions/new" element={<DivisionsNew />} />
+          </Routes>
+        </Box>
       </AuthProvider>
     </BrowserRouter>
   );

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { css, Global } from "@emotion/react";
 import { AuthProvider } from "./providers/AuthProvider";
 import Home from "./pages/Home";
 import Header from "./components/Header";
@@ -13,8 +14,15 @@ import DivisionsNew from "./pages/DivisionsNew";
 import TasksEdit from "./pages/TasksEdit";
 
 const App: React.FC = () => {
+  const global = css`
+    * {
+      margin: 0;
+    }
+  `;
+
   return (
     <BrowserRouter>
+      <Global styles={global} />
       <AuthProvider>
         <Header />
         <Routes>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,7 +1,14 @@
 import { FC, useContext } from "react";
 import { useNavigate } from "react-router-dom";
 import Cookies from "js-cookie";
-import { AppBar, Toolbar, Typography } from "@mui/material";
+import {
+  AppBar,
+  Box,
+  Button,
+  Container,
+  Toolbar,
+  Typography,
+} from "@mui/material";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { axiosInstance } from "../utils/axios";
 import { AuthContext } from "../providers/AuthProvider";
@@ -39,33 +46,44 @@ const Header: FC = () => {
 
   return (
     <AppBar position="static">
-      <Toolbar>
-        <Typography
-          variant="h5"
-          component="a"
-          href="/"
-          sx={{
-            flexGrow: 1,
-            color: "inherit",
-            textDecoration: "none",
-          }}
-        >
-          DivWork
-        </Typography>
-        {isSignedIn && (
-          <div>
-            <h4>{currentUser?.name}</h4>
-            <button type="submit" onClick={onClickSignOut}>
-              サインアウト
-            </button>
-          </div>
-        )}
-        {isSignedIn || (
-          <div>
-            <h4>サインイン</h4>
-          </div>
-        )}
-      </Toolbar>
+      <Container maxWidth="xl">
+        <Toolbar disableGutters>
+          <Typography
+            variant="h5"
+            component="a"
+            href="/"
+            sx={{
+              flexGrow: 1,
+              display: { xs: "flex" },
+              color: "inherit",
+              textDecoration: "none",
+            }}
+          >
+            DivWork
+          </Typography>
+          {isSignedIn && (
+            <Box sx={{ flexGrow: 0, display: { xs: "flex" } }}>
+              <Button sx={{ my: 2, color: "white", display: "block" }}>
+                {currentUser?.name}
+              </Button>
+              <Button
+                type="submit"
+                onClick={onClickSignOut}
+                sx={{ my: 2, color: "white", display: "block" }}
+              >
+                サインアウト
+              </Button>
+            </Box>
+          )}
+          {isSignedIn || (
+            <Box sx={{ flexGrow: 0, display: { xs: "flex" } }}>
+              <Button sx={{ my: 2, color: "white", display: "block" }}>
+                サインイン
+              </Button>
+            </Box>
+          )}
+        </Toolbar>
+      </Container>
     </AppBar>
   );
 };

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -77,6 +77,14 @@ const Header: FC = () => {
           )}
           {isSignedIn || (
             <Box sx={{ flexGrow: 0, display: { xs: "flex" } }}>
+              <Link
+                style={{ textDecoration: "none" }}
+                to="/sign_up/teams/select"
+              >
+                <Button sx={{ my: 2, color: "white", display: "block" }}>
+                  サインアップ
+                </Button>
+              </Link>
               <Link style={{ textDecoration: "none" }} to="/sign_in">
                 <Button sx={{ my: 2, color: "white", display: "block" }}>
                   サインイン

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,14 +1,13 @@
 import { FC, useContext } from "react";
 import { useNavigate } from "react-router-dom";
 import Cookies from "js-cookie";
-import { AppBar } from "@mui/material";
+import { AppBar, Toolbar, Typography } from "@mui/material";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { axiosInstance } from "../utils/axios";
 import { AuthContext } from "../providers/AuthProvider";
 
 const Header: FC = () => {
   const { isSignedIn, setIsSignedIn, currentUser } = useContext(AuthContext);
-
   const navigate = useNavigate();
 
   const onClickSignOut = () => {
@@ -40,7 +39,19 @@ const Header: FC = () => {
 
   return (
     <AppBar position="static">
-      <>
+      <Toolbar>
+        <Typography
+          variant="h5"
+          component="a"
+          href="/"
+          sx={{
+            flexGrow: 1,
+            color: "inherit",
+            textDecoration: "none",
+          }}
+        >
+          DivWork
+        </Typography>
         {isSignedIn && (
           <div>
             <h4>{currentUser?.name}</h4>
@@ -54,7 +65,7 @@ const Header: FC = () => {
             <h4>サインイン</h4>
           </div>
         )}
-      </>
+      </Toolbar>
     </AppBar>
   );
 };

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -37,20 +37,21 @@ const Header: FC = () => {
       .catch((err) => console.log(err));
   };
 
-  if (isSignedIn === true) {
-    return (
-      <div>
-        <h4>{currentUser?.name}</h4>
-        <button type="submit" onClick={onClickSignOut}>
-          サインアウト
-        </button>
-      </div>
-    );
-  }
-
   return (
     <div>
-      <h4>サインイン</h4>
+      {isSignedIn && (
+        <div>
+          <h4>{currentUser?.name}</h4>
+          <button type="submit" onClick={onClickSignOut}>
+            サインアウト
+          </button>
+        </div>
+      )}
+      {isSignedIn || (
+        <div>
+          <h4>サインイン</h4>
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,7 +1,8 @@
-import { AxiosRequestConfig, AxiosResponse } from "axios";
-import Cookies from "js-cookie";
 import { FC, useContext } from "react";
 import { useNavigate } from "react-router-dom";
+import Cookies from "js-cookie";
+import { AppBar } from "@mui/material";
+import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { axiosInstance } from "../utils/axios";
 import { AuthContext } from "../providers/AuthProvider";
 
@@ -38,21 +39,23 @@ const Header: FC = () => {
   };
 
   return (
-    <div>
-      {isSignedIn && (
-        <div>
-          <h4>{currentUser?.name}</h4>
-          <button type="submit" onClick={onClickSignOut}>
-            サインアウト
-          </button>
-        </div>
-      )}
-      {isSignedIn || (
-        <div>
-          <h4>サインイン</h4>
-        </div>
-      )}
-    </div>
+    <AppBar position="static">
+      <>
+        {isSignedIn && (
+          <div>
+            <h4>{currentUser?.name}</h4>
+            <button type="submit" onClick={onClickSignOut}>
+              サインアウト
+            </button>
+          </div>
+        )}
+        {isSignedIn || (
+          <div>
+            <h4>サインイン</h4>
+          </div>
+        )}
+      </>
+    </AppBar>
   );
 };
 

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,5 +1,5 @@
 import { FC, useContext } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, Link } from "react-router-dom";
 import Cookies from "js-cookie";
 import {
   AppBar,
@@ -77,9 +77,11 @@ const Header: FC = () => {
           )}
           {isSignedIn || (
             <Box sx={{ flexGrow: 0, display: { xs: "flex" } }}>
-              <Button sx={{ my: 2, color: "white", display: "block" }}>
-                サインイン
-              </Button>
+              <Link style={{ textDecoration: "none" }} to="/sign_in">
+                <Button sx={{ my: 2, color: "white", display: "block" }}>
+                  サインイン
+                </Button>
+              </Link>
             </Box>
           )}
         </Toolbar>

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,17 +1,28 @@
 import { FC } from "react";
 import { Link } from "react-router-dom";
+import { Button, Container, Grid } from "@mui/material";
 
 const Home: FC = () => {
   return (
-    <div className="Home">
+    <Container maxWidth="sm">
       <h1>DivWork</h1>
-      <div>
-        <Link to="/sign_up/teams/select">サインアップ</Link>
-      </div>
-      <div>
-        <Link to="/sign_in">サインイン</Link>
-      </div>
-    </div>
+      <Grid container direction="column" spacing={2}>
+        <Grid item>
+          <Link style={{ textDecoration: "none" }} to="/sign_up/teams/select">
+            <Button variant="contained" type="button">
+              サインアップ
+            </Button>
+          </Link>
+        </Grid>
+        <Grid item>
+          <Link style={{ textDecoration: "none" }} to="/sign_in">
+            <Button variant="outlined" type="button">
+              サインイン
+            </Button>
+          </Link>
+        </Grid>
+      </Grid>
+    </Container>
   );
 };
 

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,11 +1,13 @@
 import { FC } from "react";
 import { Link } from "react-router-dom";
-import { Button, Container, Grid } from "@mui/material";
+import { Button, Container, Grid, Typography } from "@mui/material";
 
 const Home: FC = () => {
   return (
     <Container maxWidth="sm">
-      <h1>DivWork</h1>
+      <Typography variant="h2" component="div" gutterBottom>
+        DivWork
+      </Typography>
       <Grid container direction="column" spacing={2}>
         <Grid item>
           <Link style={{ textDecoration: "none" }} to="/sign_up/teams/select">

--- a/frontend/src/tests/__snapshots__/Header.test.tsx.snap
+++ b/frontend/src/tests/__snapshots__/Header.test.tsx.snap
@@ -1,9 +1,86 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Header スナップショット 1`] = `
-<div>
-  <h4>
-    サインイン
-  </h4>
-</div>
+<header
+  className="MuiPaper-root MuiPaper-elevation MuiPaper-elevation4 MuiAppBar-root MuiAppBar-colorPrimary MuiAppBar-positionStatic css-hip9hq-MuiPaper-root-MuiAppBar-root"
+>
+  <div
+    className="MuiContainer-root MuiContainer-maxWidthXl css-19r6kue-MuiContainer-root"
+  >
+    <div
+      className="MuiToolbar-root MuiToolbar-regular css-r6ewbb-MuiToolbar-root"
+    >
+      <a
+        className="MuiTypography-root MuiTypography-h5 css-1tn41p-MuiTypography-root"
+        href="/"
+      >
+        DivWork
+      </a>
+      <div
+        className="MuiBox-root css-7ln23k"
+      >
+        <a
+          href="/sign_up/teams/select"
+          onClick={[Function]}
+          style={
+            Object {
+              "textDecoration": "none",
+            }
+          }
+        >
+          <button
+            className="MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButtonBase-root  css-1q39md6-MuiButtonBase-root-MuiButton-root"
+            disabled={false}
+            onBlur={[Function]}
+            onContextMenu={[Function]}
+            onDragLeave={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={0}
+            type="button"
+          >
+            サインアップ
+          </button>
+        </a>
+        <a
+          href="/sign_in"
+          onClick={[Function]}
+          style={
+            Object {
+              "textDecoration": "none",
+            }
+          }
+        >
+          <button
+            className="MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButtonBase-root  css-1q39md6-MuiButtonBase-root-MuiButton-root"
+            disabled={false}
+            onBlur={[Function]}
+            onContextMenu={[Function]}
+            onDragLeave={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={0}
+            type="button"
+          >
+            サインイン
+          </button>
+        </a>
+      </div>
+    </div>
+  </div>
+</header>
 `;

--- a/frontend/src/tests/__snapshots__/Home.test.tsx.snap
+++ b/frontend/src/tests/__snapshots__/Home.test.tsx.snap
@@ -2,26 +2,84 @@
 
 exports[`Home スナップショット 1`] = `
 <div
-  className="Home"
+  className="MuiContainer-root MuiContainer-maxWidthSm css-cuefkz-MuiContainer-root"
 >
-  <h1>
+  <div
+    className="MuiTypography-root MuiTypography-h2 MuiTypography-gutterBottom css-i1hrn3-MuiTypography-root"
+  >
     DivWork
-  </h1>
-  <div>
-    <a
-      href="/sign_up/teams/select"
-      onClick={[Function]}
-    >
-      サインアップ
-    </a>
   </div>
-  <div>
-    <a
-      href="/sign_in"
-      onClick={[Function]}
+  <div
+    className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-direction-xs-column css-1rl1og4-MuiGrid-root"
+  >
+    <div
+      className="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
     >
-      サインイン
-    </a>
+      <a
+        href="/sign_up/teams/select"
+        onClick={[Function]}
+        style={
+          Object {
+            "textDecoration": "none",
+          }
+        }
+      >
+        <button
+          className="MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root  css-sghohy-MuiButtonBase-root-MuiButton-root"
+          disabled={false}
+          onBlur={[Function]}
+          onContextMenu={[Function]}
+          onDragLeave={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          tabIndex={0}
+          type="button"
+        >
+          サインアップ
+        </button>
+      </a>
+    </div>
+    <div
+      className="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+    >
+      <a
+        href="/sign_in"
+        onClick={[Function]}
+        style={
+          Object {
+            "textDecoration": "none",
+          }
+        }
+      >
+        <button
+          className="MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButtonBase-root  css-1rwt2y5-MuiButtonBase-root-MuiButton-root"
+          disabled={false}
+          onBlur={[Function]}
+          onContextMenu={[Function]}
+          onDragLeave={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          tabIndex={0}
+          type="button"
+        >
+          サインイン
+        </button>
+      </a>
+    </div>
   </div>
 </div>
 `;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -18,9 +14,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "jsxImportSource": "@emotion/react"
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1318,6 +1318,11 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
+"@fontsource/roboto@^4.5.7":
+  version "4.5.7"
+  resolved "https://registry.yarnpkg.com/@fontsource/roboto/-/roboto-4.5.7.tgz#292740a52fa2bac61b89f92e1c588037defe65cb"
+  integrity sha512-m57UMER23Mk6Drg9OjtHW1Y+0KPGyZfE5XJoPTOsLARLar6013kJj4X2HICt+iFLJqIgTahA/QAvSn9lwF1EEw==
+
 "@humanwhocodes/config-array@^0.9.2":
   version "0.9.5"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.9.5.tgz#2cbaf9a89460da24b5ca6531b8bbfc23e1df50c7"


### PR DESCRIPTION
### 目的
レイアウト作成を進めるため。

### 変更内容
- `Home.tsx`にmuiコンポーネントを導入
- `Header.tsx`にmuiコンポーネントを導入
- ブラウザの`margin: 8px`を打ち消し
- ページに`padding, margin`を設定
- Robotoフォントの導入