### PR TITLE
feat: SignUp, SignInページのレイアウト作成 #105

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -61,37 +61,39 @@ const Header: FC = () => {
           >
             DivWork
           </Typography>
-          {isSignedIn && (
-            <Box sx={{ flexGrow: 0, display: { xs: "flex" } }}>
-              <Button sx={{ my: 2, color: "white", display: "block" }}>
-                {currentUser?.name}
-              </Button>
-              <Button
-                type="submit"
-                onClick={onClickSignOut}
-                sx={{ my: 2, color: "white", display: "block" }}
-              >
-                サインアウト
-              </Button>
-            </Box>
-          )}
-          {isSignedIn || (
-            <Box sx={{ flexGrow: 0, display: { xs: "flex" } }}>
-              <Link
-                style={{ textDecoration: "none" }}
-                to="/sign_up/teams/select"
-              >
+          <>
+            {isSignedIn && (
+              <Box sx={{ flexGrow: 0, display: { xs: "flex" } }}>
                 <Button sx={{ my: 2, color: "white", display: "block" }}>
-                  サインアップ
+                  {currentUser?.name}
                 </Button>
-              </Link>
-              <Link style={{ textDecoration: "none" }} to="/sign_in">
-                <Button sx={{ my: 2, color: "white", display: "block" }}>
-                  サインイン
+                <Button
+                  type="submit"
+                  onClick={onClickSignOut}
+                  sx={{ my: 2, color: "white", display: "block" }}
+                >
+                  サインアウト
                 </Button>
-              </Link>
-            </Box>
-          )}
+              </Box>
+            )}
+            {isSignedIn || (
+              <Box sx={{ flexGrow: 0, display: { xs: "flex" } }}>
+                <Link
+                  style={{ textDecoration: "none" }}
+                  to="/sign_up/teams/select"
+                >
+                  <Button sx={{ my: 2, color: "white", display: "block" }}>
+                    サインアップ
+                  </Button>
+                </Link>
+                <Link style={{ textDecoration: "none" }} to="/sign_in">
+                  <Button sx={{ my: 2, color: "white", display: "block" }}>
+                    サインイン
+                  </Button>
+                </Link>
+              </Box>
+            )}
+          </>
         </Toolbar>
       </Container>
     </AppBar>

--- a/frontend/src/pages/SignIn.tsx
+++ b/frontend/src/pages/SignIn.tsx
@@ -1,10 +1,11 @@
-import { AxiosRequestConfig, AxiosResponse } from "axios";
-import Cookies from "js-cookie";
 import { FC, useContext, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import Cookies from "js-cookie";
+import { Button, Container, Grid, TextField, Typography } from "@mui/material";
+import { AxiosRequestConfig, AxiosResponse } from "axios";
+import { axiosInstance } from "../utils/axios";
 import { AuthContext } from "../providers/AuthProvider";
 import { AuthResponse } from "../types";
-import { axiosInstance } from "../utils/axios";
 
 const SignIn: FC = () => {
   const [email, setEmail] = useState<string>("");
@@ -38,26 +39,38 @@ const SignIn: FC = () => {
   };
 
   return (
-    <div>
-      <h1>Sign In</h1>
-      <div>
-        <input
-          value={email}
-          onChange={(event) => setEmail(event.target.value)}
-        />
-      </div>
-      <div>
-        <input
-          value={password}
-          onChange={(event) => setPassword(event.target.value)}
-        />
-      </div>
-      <div>
-        <button type="submit" onClick={onClickSignIn}>
-          サインイン
-        </button>
-      </div>
-    </div>
+    <Container maxWidth="sm">
+      <Grid container direction="column" spacing={3}>
+        <Grid item>
+          <Typography variant="h4" component="div">
+            サインイン
+          </Typography>
+        </Grid>
+        <Grid item>
+          <TextField
+            label="メールアドレス"
+            variant="standard"
+            sx={{ width: "30ch" }}
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+          />
+        </Grid>
+        <Grid item>
+          <TextField
+            label="パスワード"
+            variant="standard"
+            sx={{ width: "30ch" }}
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+          />
+        </Grid>
+        <Grid item>
+          <Button variant="contained" type="submit" onClick={onClickSignIn}>
+            サインイン
+          </Button>
+        </Grid>
+      </Grid>
+    </Container>
   );
 };
 

--- a/frontend/src/pages/SignIn.tsx
+++ b/frontend/src/pages/SignIn.tsx
@@ -48,6 +48,7 @@ const SignIn: FC = () => {
         </Grid>
         <Grid item>
           <TextField
+            type="email"
             label="メールアドレス"
             variant="standard"
             sx={{ width: "30ch" }}
@@ -57,6 +58,7 @@ const SignIn: FC = () => {
         </Grid>
         <Grid item>
           <TextField
+            type="password"
             label="パスワード"
             variant="standard"
             sx={{ width: "30ch" }}

--- a/frontend/src/pages/SignUp.tsx
+++ b/frontend/src/pages/SignUp.tsx
@@ -1,12 +1,13 @@
-import { AxiosRequestConfig, AxiosResponse } from "axios";
-import Cookies from "js-cookie";
 import { FC, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
-import { AuthResponse, Team } from "../types/index";
+import Cookies from "js-cookie";
+import { Container } from "@mui/material";
+import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { axiosInstance } from "../utils/axios";
+import { AuthResponse } from "../types/index";
 
 type State = {
-  selectTeam: Team;
+  selectTeamId: number;
 };
 
 const SignUp: FC = () => {
@@ -17,7 +18,7 @@ const SignUp: FC = () => {
   const navigate = useNavigate();
 
   const location = useLocation();
-  const { selectTeam } = location.state as State;
+  const { selectTeamId } = location.state as State;
 
   const onClickSignUp = () => {
     const options: AxiosRequestConfig = {
@@ -27,7 +28,7 @@ const SignUp: FC = () => {
         name,
         email,
         password,
-        team_id: selectTeam.id,
+        team_id: selectTeamId,
       },
     };
 
@@ -47,9 +48,11 @@ const SignUp: FC = () => {
   };
 
   return (
-    <div>
-      <h1>Sign Up</h1>
-      <div>{selectTeam.name}</div>
+    <Container maxWidth="sm">
+      <h1>
+        サインアップ
+      </h1>
+      <div>{selectTeamId}</div>
       <div>
         <input value={name} onChange={(event) => setName(event.target.value)} />
       </div>
@@ -70,7 +73,7 @@ const SignUp: FC = () => {
           サインアップ
         </button>
       </div>
-    </div>
+      </Container>
   );
 };
 

--- a/frontend/src/pages/SignUp.tsx
+++ b/frontend/src/pages/SignUp.tsx
@@ -63,6 +63,7 @@ const SignUp: FC = () => {
         </Grid>
         <Grid item>
           <TextField
+            type="text"
             label="ユーザー名"
             variant="standard"
             sx={{ width: "30ch" }}
@@ -72,6 +73,7 @@ const SignUp: FC = () => {
         </Grid>
         <Grid item>
           <TextField
+            type="email"
             label="メールアドレス"
             variant="standard"
             sx={{ width: "30ch" }}
@@ -81,6 +83,7 @@ const SignUp: FC = () => {
         </Grid>
         <Grid item>
           <TextField
+            type="password"
             label="パスワード"
             variant="standard"
             sx={{ width: "30ch" }}

--- a/frontend/src/pages/SignUp.tsx
+++ b/frontend/src/pages/SignUp.tsx
@@ -7,7 +7,8 @@ import { axiosInstance } from "../utils/axios";
 import { AuthResponse } from "../types/index";
 
 type State = {
-  selectTeamId: number;
+  teamId: number;
+  teamName: string;
 };
 
 const SignUp: FC = () => {
@@ -18,7 +19,7 @@ const SignUp: FC = () => {
   const navigate = useNavigate();
 
   const location = useLocation();
-  const { selectTeamId } = location.state as State;
+  const { teamId, teamName } = location.state as State;
 
   const onClickSignUp = () => {
     const options: AxiosRequestConfig = {
@@ -28,7 +29,7 @@ const SignUp: FC = () => {
         name,
         email,
         password,
-        team_id: selectTeamId,
+        team_id: teamId,
       },
     };
 
@@ -55,7 +56,11 @@ const SignUp: FC = () => {
             サインアップ
           </Typography>
         </Grid>
-        <Grid item>{selectTeamId}</Grid>
+        <Grid item>
+          <Typography variant="h6" component="div">
+            {teamName}
+          </Typography>
+        </Grid>
         <Grid item>
           <TextField
             label="ユーザー名"

--- a/frontend/src/pages/SignUp.tsx
+++ b/frontend/src/pages/SignUp.tsx
@@ -1,7 +1,7 @@
 import { FC, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import Cookies from "js-cookie";
-import { Container } from "@mui/material";
+import { Button, Container, Grid, TextField, Typography } from "@mui/material";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { axiosInstance } from "../utils/axios";
 import { AuthResponse } from "../types/index";
@@ -49,31 +49,47 @@ const SignUp: FC = () => {
 
   return (
     <Container maxWidth="sm">
-      <h1>
-        サインアップ
-      </h1>
-      <div>{selectTeamId}</div>
-      <div>
-        <input value={name} onChange={(event) => setName(event.target.value)} />
-      </div>
-      <div>
-        <input
-          value={email}
-          onChange={(event) => setEmail(event.target.value)}
-        />
-      </div>
-      <div>
-        <input
-          value={password}
-          onChange={(event) => setPassword(event.target.value)}
-        />
-      </div>
-      <div>
-        <button type="submit" onClick={onClickSignUp}>
-          サインアップ
-        </button>
-      </div>
-      </Container>
+      <Grid container direction="column" spacing={3}>
+        <Grid item>
+          <Typography variant="h4" component="div">
+            サインアップ
+          </Typography>
+        </Grid>
+        <Grid item>{selectTeamId}</Grid>
+        <Grid item>
+          <TextField
+            label="ユーザー名"
+            variant="standard"
+            sx={{ width: "30ch" }}
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+          />
+        </Grid>
+        <Grid item>
+          <TextField
+            label="メールアドレス"
+            variant="standard"
+            sx={{ width: "30ch" }}
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+          />
+        </Grid>
+        <Grid item>
+          <TextField
+            label="パスワード"
+            variant="standard"
+            sx={{ width: "30ch" }}
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+          />
+        </Grid>
+        <Grid item>
+          <Button variant="contained" type="submit" onClick={onClickSignUp}>
+            サインアップ
+          </Button>
+        </Grid>
+      </Grid>
+    </Container>
   );
 };
 

--- a/frontend/src/pages/TeamsSelect.tsx
+++ b/frontend/src/pages/TeamsSelect.tsx
@@ -1,12 +1,13 @@
 import { FC, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
-import { Container, Typography } from "@mui/material";
+import { Container, MenuItem, TextField, Typography } from "@mui/material";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { axiosInstance } from "../utils/axios";
 import { Team, TeamsSelectResponse } from "../types";
 
 const TeamsSelect: FC = () => {
   const [teams, setTeams] = useState<Team[]>([]);
+  const [value, setValue] = useState<string>("");
 
   const options: AxiosRequestConfig = {
     url: "/teams/select",
@@ -33,19 +34,29 @@ const TeamsSelect: FC = () => {
         選択したチームのユーザーを作成します。
       </Typography>
       <div>
-        <ul>
+        <TextField
+          select
+          label="チーム"
+          sx={{ width: "25ch" }}
+          name="team"
+          value={value}
+          onChange={(event) => setValue(event.target.value)}
+        >
           {teams?.map((team) => (
-            <Link
-              style={{ textDecoration: "none" }}
-              to="/sign_up"
-              key={team.id}
-              state={{ selectTeam: team }}
-            >
-              <li>{team.name}</li>
-            </Link>
+            <MenuItem key={team.id} value={team.id}>
+              {team.name}
+            </MenuItem>
           ))}
-        </ul>
+        </TextField>
       </div>
+      <Link
+        style={{ textDecoration: "none" }}
+        to="/sign_up"
+        key={value}
+        state={{ selectTeam: value }}
+      >
+        次へ
+      </Link>
     </Container>
   );
 };

--- a/frontend/src/pages/TeamsSelect.tsx
+++ b/frontend/src/pages/TeamsSelect.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useState } from "react";
+import { ChangeEvent, FC, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import {
   Button,
@@ -14,7 +14,8 @@ import { Team, TeamsSelectResponse } from "../types";
 
 const TeamsSelect: FC = () => {
   const [teams, setTeams] = useState<Team[]>([]);
-  const [teamId, setTeamId] = useState<string>();
+  const [teamId, setTeamId] = useState<string>("");
+  const [teamName, setTeamName] = useState<string>("");
 
   const options: AxiosRequestConfig = {
     url: "/teams/select",
@@ -32,6 +33,21 @@ const TeamsSelect: FC = () => {
       });
   }, []);
 
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const { value } = event.target;
+    setTeamId(value);
+
+    const teamIdNumber = Number(value);
+    const selectTeam: Team | undefined = teams.find(
+      (v) => v.id === teamIdNumber
+    );
+    console.log(selectTeam);
+
+    if (selectTeam) {
+      setTeamName(selectTeam.name);
+    }
+  };
+
   return (
     <Container maxWidth="sm">
       <Grid container direction="column" spacing={3}>
@@ -48,15 +64,14 @@ const TeamsSelect: FC = () => {
             select
             label="チーム"
             sx={{ width: "25ch" }}
-            name="team"
+            name="id"
             value={teamId}
-            onChange={(event) => {
-              setTeamId(event.target.value);
-            }}
+            defaultValue=""
+            onChange={handleChange}
           >
-            {teams?.map((team) => (
-              <MenuItem key={team.id} value={team.id}>
-                {team.name}
+            {teams?.map((menu) => (
+              <MenuItem key={menu.id} value={menu.id}>
+                {menu.name}
               </MenuItem>
             ))}
           </TextField>
@@ -66,7 +81,7 @@ const TeamsSelect: FC = () => {
             style={{ textDecoration: "none" }}
             to="/sign_up"
             key={teamId}
-            state={{ selectTeamId: teamId }}
+            state={{ teamId, teamName }}
           >
             <Button variant="contained" type="button">
               次へ

--- a/frontend/src/pages/TeamsSelect.tsx
+++ b/frontend/src/pages/TeamsSelect.tsx
@@ -14,7 +14,7 @@ import { Team, TeamsSelectResponse } from "../types";
 
 const TeamsSelect: FC = () => {
   const [teams, setTeams] = useState<Team[]>([]);
-  const [value, setValue] = useState<string>("");
+  const [teamId, setTeamId] = useState<string>();
 
   const options: AxiosRequestConfig = {
     url: "/teams/select",
@@ -49,8 +49,10 @@ const TeamsSelect: FC = () => {
             label="チーム"
             sx={{ width: "25ch" }}
             name="team"
-            value={value}
-            onChange={(event) => setValue(event.target.value)}
+            value={teamId}
+            onChange={(event) => {
+              setTeamId(event.target.value);
+            }}
           >
             {teams?.map((team) => (
               <MenuItem key={team.id} value={team.id}>
@@ -63,8 +65,8 @@ const TeamsSelect: FC = () => {
           <Link
             style={{ textDecoration: "none" }}
             to="/sign_up"
-            key={value}
-            state={{ selectTeam: value }}
+            key={teamId}
+            state={{ selectTeamId: teamId }}
           >
             <Button variant="contained" type="button">
               次へ

--- a/frontend/src/pages/TeamsSelect.tsx
+++ b/frontend/src/pages/TeamsSelect.tsx
@@ -1,8 +1,9 @@
-import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { FC, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
-import { Team, TeamsSelectResponse } from "../types";
+import { Container, Typography } from "@mui/material";
+import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { axiosInstance } from "../utils/axios";
+import { Team, TeamsSelectResponse } from "../types";
 
 const TeamsSelect: FC = () => {
   const [teams, setTeams] = useState<Team[]>([]);
@@ -24,18 +25,28 @@ const TeamsSelect: FC = () => {
   }, []);
 
   return (
-    <div>
-      <h1>Teams#Select</h1>
+    <Container>
+      <Typography variant="h4" component="div" gutterBottom>
+        所属チームの選択
+      </Typography>
+      <Typography variant="subtitle1" component="div">
+        選択したチームのユーザーを作成します。
+      </Typography>
       <div>
         <ul>
           {teams?.map((team) => (
-            <Link to="/sign_up" key={team.id} state={{ selectTeam: team }}>
+            <Link
+              style={{ textDecoration: "none" }}
+              to="/sign_up"
+              key={team.id}
+              state={{ selectTeam: team }}
+            >
               <li>{team.name}</li>
             </Link>
           ))}
         </ul>
       </div>
-    </div>
+    </Container>
   );
 };
 

--- a/frontend/src/pages/TeamsSelect.tsx
+++ b/frontend/src/pages/TeamsSelect.tsx
@@ -1,6 +1,13 @@
 import { FC, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
-import { Container, MenuItem, TextField, Typography } from "@mui/material";
+import {
+  Button,
+  Container,
+  Grid,
+  MenuItem,
+  TextField,
+  Typography,
+} from "@mui/material";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { axiosInstance } from "../utils/axios";
 import { Team, TeamsSelectResponse } from "../types";
@@ -26,37 +33,45 @@ const TeamsSelect: FC = () => {
   }, []);
 
   return (
-    <Container>
-      <Typography variant="h4" component="div" gutterBottom>
-        所属チームの選択
-      </Typography>
-      <Typography variant="subtitle1" component="div">
-        選択したチームのユーザーを作成します。
-      </Typography>
-      <div>
-        <TextField
-          select
-          label="チーム"
-          sx={{ width: "25ch" }}
-          name="team"
-          value={value}
-          onChange={(event) => setValue(event.target.value)}
-        >
-          {teams?.map((team) => (
-            <MenuItem key={team.id} value={team.id}>
-              {team.name}
-            </MenuItem>
-          ))}
-        </TextField>
-      </div>
-      <Link
-        style={{ textDecoration: "none" }}
-        to="/sign_up"
-        key={value}
-        state={{ selectTeam: value }}
-      >
-        次へ
-      </Link>
+    <Container maxWidth="sm">
+      <Grid container direction="column" spacing={3}>
+        <Grid item>
+          <Typography variant="h4" component="div" gutterBottom>
+            所属チームの選択
+          </Typography>
+          <Typography variant="subtitle1" component="div">
+            選択したチームのユーザーを作成します。
+          </Typography>
+        </Grid>
+        <Grid item>
+          <TextField
+            select
+            label="チーム"
+            sx={{ width: "25ch" }}
+            name="team"
+            value={value}
+            onChange={(event) => setValue(event.target.value)}
+          >
+            {teams?.map((team) => (
+              <MenuItem key={team.id} value={team.id}>
+                {team.name}
+              </MenuItem>
+            ))}
+          </TextField>
+        </Grid>
+        <Grid item>
+          <Link
+            style={{ textDecoration: "none" }}
+            to="/sign_up"
+            key={value}
+            state={{ selectTeam: value }}
+          >
+            <Button variant="contained" type="button">
+              次へ
+            </Button>
+          </Link>
+        </Grid>
+      </Grid>
     </Container>
   );
 };

--- a/frontend/src/tests/SignIn.test.tsx
+++ b/frontend/src/tests/SignIn.test.tsx
@@ -1,29 +1,8 @@
-import { render, screen } from "@testing-library/react";
 import renderer from "react-test-renderer"; // eslint-disable-line import/no-extraneous-dependencies
 import { BrowserRouter } from "react-router-dom";
 import SignIn from "../pages/SignIn";
 
 describe("SignIn", () => {
-  test("'Sign In'が表示されていること", () => {
-    render(
-      <BrowserRouter>
-        <SignIn />
-      </BrowserRouter>
-    );
-    const textElement = screen.getByText("Sign In");
-    expect(textElement).toBeInTheDocument();
-  });
-
-  test("'サインイン'が表示されていること", () => {
-    render(
-      <BrowserRouter>
-        <SignIn />
-      </BrowserRouter>
-    );
-    const textElement = screen.getByText("サインイン");
-    expect(textElement).toBeInTheDocument();
-  });
-
   test("スナップショット", () => {
     const tree = renderer
       .create(

--- a/frontend/src/tests/__snapshots__/SignIn.test.tsx.snap
+++ b/frontend/src/tests/__snapshots__/SignIn.test.tsx.snap
@@ -1,29 +1,116 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SignIn スナップショット 1`] = `
-<div>
-  <h1>
-    Sign In
-  </h1>
-  <div>
-    <input
-      onChange={[Function]}
-      value=""
-    />
-  </div>
-  <div>
-    <input
-      onChange={[Function]}
-      value=""
-    />
-  </div>
-  <div>
-    <button
-      onClick={[Function]}
-      type="submit"
+<div
+  className="MuiContainer-root MuiContainer-maxWidthSm css-cuefkz-MuiContainer-root"
+>
+  <div
+    className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-3 MuiGrid-direction-xs-column css-32q0xd-MuiGrid-root"
+  >
+    <div
+      className="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
     >
-      サインイン
-    </button>
+      <div
+        className="MuiTypography-root MuiTypography-h4 css-5lbw0b-MuiTypography-root"
+      >
+        サインイン
+      </div>
+    </div>
+    <div
+      className="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+    >
+      <div
+        className="MuiFormControl-root MuiTextField-root css-tghzsf-MuiFormControl-root-MuiTextField-root"
+      >
+        <label
+          className="MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-standard MuiFormLabel-root MuiFormLabel-colorPrimary css-aqpgxn-MuiFormLabel-root-MuiInputLabel-root"
+          data-shrink={false}
+          htmlFor=":r0:"
+          id=":r0:-label"
+        >
+          メールアドレス
+        </label>
+        <div
+          className="MuiInput-root MuiInput-underline MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl css-1ptx2yq-MuiInputBase-root-MuiInput-root"
+          onClick={[Function]}
+        >
+          <input
+            aria-invalid={false}
+            autoFocus={false}
+            className="MuiInput-input MuiInputBase-input css-1x51dt5-MuiInputBase-input-MuiInput-input"
+            disabled={false}
+            id=":r0:"
+            onAnimationStart={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            required={false}
+            type="email"
+            value=""
+          />
+        </div>
+      </div>
+    </div>
+    <div
+      className="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+    >
+      <div
+        className="MuiFormControl-root MuiTextField-root css-tghzsf-MuiFormControl-root-MuiTextField-root"
+      >
+        <label
+          className="MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-standard MuiFormLabel-root MuiFormLabel-colorPrimary css-aqpgxn-MuiFormLabel-root-MuiInputLabel-root"
+          data-shrink={false}
+          htmlFor=":r1:"
+          id=":r1:-label"
+        >
+          パスワード
+        </label>
+        <div
+          className="MuiInput-root MuiInput-underline MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl css-1ptx2yq-MuiInputBase-root-MuiInput-root"
+          onClick={[Function]}
+        >
+          <input
+            aria-invalid={false}
+            autoFocus={false}
+            className="MuiInput-input MuiInputBase-input css-1x51dt5-MuiInputBase-input-MuiInput-input"
+            disabled={false}
+            id=":r1:"
+            onAnimationStart={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            required={false}
+            type="password"
+            value=""
+          />
+        </div>
+      </div>
+    </div>
+    <div
+      className="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+    >
+      <button
+        className="MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root  css-sghohy-MuiButtonBase-root-MuiButton-root"
+        disabled={false}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onContextMenu={[Function]}
+        onDragLeave={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
+        tabIndex={0}
+        type="submit"
+      >
+        サインイン
+      </button>
+    </div>
   </div>
 </div>
 `;


### PR DESCRIPTION
### 変更内容
- `TeamsSelect`, `SignUp`, `SignIn`ページにmuiコンポーネントを導入
- `TeamsSelect`から`SignUp`ページに遷移する際、`teamId`, `teamName`をpropsとして保持するよう修正