### PR TITLE
fix: AuthProviderのトリガーをisSignedInに変更

### DIFF
--- a/frontend/src/providers/AuthProvider.tsx
+++ b/frontend/src/providers/AuthProvider.tsx
@@ -60,7 +60,7 @@ export const AuthProvider: FC<Props> = ({ children }) => {
         }
       })
       .catch((err) => console.log(err));
-  }, [setIsSignedIn]);
+  }, [isSignedIn]);
 
   return (
     <AuthContext.Provider value={AuthProviderValue}>


### PR DESCRIPTION
### 変更理由
サインイン直後にユーザー名が表示されないバグを解消するため。

### 変更内容
- `AuthProvider`のトリガーを`isSignedIn`に変更