### PR TITLE
fix: ロード中に不適切にページ遷移する問題の修正 #115

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,7 @@ import "@fontsource/roboto/300.css";
 import "@fontsource/roboto/400.css";
 import "@fontsource/roboto/500.css";
 import "@fontsource/roboto/700.css";
+import PrivateRoute from "./components/PrivateRoute";
 
 const App: React.FC = () => {
   const global = css`
@@ -36,12 +37,54 @@ const App: React.FC = () => {
             <Route path="/sign_up/teams/select" element={<TeamsSelect />} />
             <Route path="/sign_up" element={<SignUp />} />
             <Route path="/sign_in" element={<SignIn />} />
-            <Route path="/teams/:id" element={<TeamsShow />} />
-            <Route path="users/:id" element={<UsersShow />} />
-            <Route path="/tasks/new" element={<TasksNew />} />
-            <Route path="/tasks/:id" element={<TasksShow />} />
-            <Route path="/tasks/:id/edit" element={<TasksEdit />} />
-            <Route path="/tasks/:id/divisions/new" element={<DivisionsNew />} />
+            <Route
+              path="/teams/:id"
+              element={
+                <PrivateRoute>
+                  <TeamsShow />
+                </PrivateRoute>
+              }
+            />
+            <Route
+              path="users/:id"
+              element={
+                <PrivateRoute>
+                  <UsersShow />
+                </PrivateRoute>
+              }
+            />
+            <Route
+              path="/tasks/new"
+              element={
+                <PrivateRoute>
+                  <TasksNew />
+                </PrivateRoute>
+              }
+            />
+            <Route
+              path="/tasks/:id"
+              element={
+                <PrivateRoute>
+                  <TasksShow />
+                </PrivateRoute>
+              }
+            />
+            <Route
+              path="/tasks/:id/edit"
+              element={
+                <PrivateRoute>
+                  <TasksEdit />
+                </PrivateRoute>
+              }
+            />
+            <Route
+              path="/tasks/:id/divisions/new"
+              element={
+                <PrivateRoute>
+                  <DivisionsNew />
+                </PrivateRoute>
+              }
+            />
           </Routes>
         </Box>
       </AuthProvider>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,6 +18,7 @@ import "@fontsource/roboto/400.css";
 import "@fontsource/roboto/500.css";
 import "@fontsource/roboto/700.css";
 import PrivateRoute from "./components/PrivateRoute";
+import PublicRoute from "./components/PublicRoute";
 
 const App: React.FC = () => {
   const global = css`
@@ -33,10 +34,38 @@ const App: React.FC = () => {
         <Header />
         <Box m={2} pt={3}>
           <Routes>
-            <Route path="/" element={<Home />} />
-            <Route path="/sign_up/teams/select" element={<TeamsSelect />} />
-            <Route path="/sign_up" element={<SignUp />} />
-            <Route path="/sign_in" element={<SignIn />} />
+            <Route
+              path="/"
+              element={
+                <PublicRoute>
+                  <Home />
+                </PublicRoute>
+              }
+            />
+            <Route
+              path="/sign_up/teams/select"
+              element={
+                <PublicRoute>
+                  <TeamsSelect />
+                </PublicRoute>
+              }
+            />
+            <Route
+              path="/sign_up"
+              element={
+                <PublicRoute>
+                  <SignUp />
+                </PublicRoute>
+              }
+            />
+            <Route
+              path="/sign_in"
+              element={
+                <PublicRoute>
+                  <SignIn />
+                </PublicRoute>
+              }
+            />
             <Route
               path="/teams/:id"
               element={

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,4 +1,4 @@
-import { FC, useContext } from "react";
+import { FC, memo, useContext } from "react";
 import { useNavigate, Link } from "react-router-dom";
 import Cookies from "js-cookie";
 import {
@@ -13,7 +13,8 @@ import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { axiosInstance } from "../utils/axios";
 import { AuthContext } from "../providers/AuthProvider";
 
-const Header: FC = () => {
+// eslint-disable-next-line react/display-name
+const Header: FC = memo(() => {
   const { isSignedIn, setIsSignedIn, currentUser } = useContext(AuthContext);
   const navigate = useNavigate();
 
@@ -98,6 +99,6 @@ const Header: FC = () => {
       </Container>
     </AppBar>
   );
-};
+});
 
 export default Header;

--- a/frontend/src/components/PrivateRoute.tsx
+++ b/frontend/src/components/PrivateRoute.tsx
@@ -1,0 +1,18 @@
+import { FC, useContext } from "react";
+import { Navigate, RouteProps } from "react-router-dom";
+import { AuthContext } from "../providers/AuthProvider";
+
+const PrivateRoute: FC<RouteProps> = ({ children }) => {
+  const { loading, isSignedIn } = useContext(AuthContext);
+
+  if (!loading) {
+    if (isSignedIn) {
+      return <div>{children}</div>;
+    }
+    return <Navigate to="/sign_in" />;
+  }
+
+  return <h5>Loading...</h5>;
+};
+
+export default PrivateRoute;

--- a/frontend/src/components/PublicRoute.tsx
+++ b/frontend/src/components/PublicRoute.tsx
@@ -1,0 +1,18 @@
+import { FC, useContext } from "react";
+import { Navigate, RouteProps } from "react-router-dom";
+import { AuthContext } from "../providers/AuthProvider";
+
+const PublicRoute: FC<RouteProps> = ({ children }) => {
+  const { loading, isSignedIn, currentUser } = useContext(AuthContext);
+
+  if (!loading) {
+    if (!isSignedIn) {
+      return <div>{children}</div>;
+    }
+    return <Navigate to={`/teams/${currentUser?.team_id}`} />;
+  }
+
+  return <h5>Loading...</h5>;
+};
+
+export default PublicRoute;

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -1,10 +1,12 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { rest } from "msw";
 import { mockSignIn, mockAuthSessions } from "./mockAuth";
+import { mockTeam } from "./mockTeam";
 import { mockTeams } from "./mockTeams";
 
 export const handlers = [
   rest.get("/teams/select", mockTeams),
   rest.post("/auth/sign_in", mockSignIn),
   rest.get("/auth/sessions", mockAuthSessions),
+  rest.get(`/teams/:id`, mockTeam),
 ];

--- a/frontend/src/mocks/mockTeam.ts
+++ b/frontend/src/mocks/mockTeam.ts
@@ -1,0 +1,50 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { MockedRequest, ResponseResolver, restContext } from "msw";
+
+export const mockTeam: ResponseResolver<MockedRequest, typeof restContext> = (
+  req,
+  res,
+  ctx
+) => {
+  return res(
+    ctx.status(200),
+    ctx.json({
+      team: {
+        id: 1,
+        name: "TEAM_1",
+        created_at: "2022-06-05T10:16:09.882+09:00",
+        updated_at: "2022-06-05T10:16:09.882+09:00",
+      },
+      users: [
+        {
+          id: 1,
+          provider: "email",
+          uid: "test@example.com",
+          allow_password_change: false,
+          name: "USER_1",
+          nickname: null,
+          image: null,
+          email: "test@example.com",
+          team_id: 1,
+          created_at: "2022-06-05T10:16:09.882+09:00",
+          updated_at: "2022-06-05T10:16:09.882+09:00",
+          tasks_count: [1, 2, 3],
+        },
+        {
+          id: 2,
+          provider: "email",
+          uid: "test2@example.com",
+          allow_password_change: false,
+          name: "USER_2",
+          nickname: null,
+          image: null,
+          email: "test2@example.com",
+          team_id: 1,
+          created_at: "2022-06-05T10:16:09.882+09:00",
+          updated_at: "2022-06-05T10:16:09.882+09:00",
+          tasks_count: [2, 3, 1],
+        },
+      ],
+    })
+  );
+};

--- a/frontend/src/pages/DivisionsNew.tsx
+++ b/frontend/src/pages/DivisionsNew.tsx
@@ -1,5 +1,5 @@
-import { ChangeEvent, FC, useContext, useEffect, useState } from "react";
-import { Navigate, useNavigate, useParams } from "react-router-dom";
+import { ChangeEvent, FC, useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
 import Cookies from "js-cookie";
 import { Button, Container, Grid, TextField } from "@mui/material";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
@@ -7,12 +7,10 @@ import { axiosInstance } from "../utils/axios";
 import { divisionTask, TasksResponse, DivisionsCreateResponse } from "../types";
 import { DeadlineTextField } from "../components/DeadlineTextField";
 import { PriorityTextField } from "../components/PriorityTextField";
-import { AuthContext } from "../providers/AuthProvider";
 
 const DivisionsNew: FC = () => {
   const params = useParams<{ id: string }>();
   const navigate = useNavigate();
-  const { isSignedIn } = useContext(AuthContext);
 
   const [task, setTask] = useState<divisionTask>({
     title: "",
@@ -81,7 +79,6 @@ const DivisionsNew: FC = () => {
 
   return (
     <Container maxWidth="sm">
-      {isSignedIn || <Navigate to="/sign_in" />}
       <h1>タスクを分担する</h1>
       <Grid container direction="column" spacing={3}>
         <Grid item>

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,5 +1,5 @@
 import { FC, useContext } from "react";
-import { Link, Navigate, useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import Cookies from "js-cookie";
 import { Button, Container, Grid, Typography } from "@mui/material";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
@@ -8,7 +8,7 @@ import { AuthResponse } from "../types";
 import { AuthContext } from "../providers/AuthProvider";
 
 const Home: FC = () => {
-  const { isSignedIn, setIsSignedIn, currentUser } = useContext(AuthContext);
+  const { setIsSignedIn } = useContext(AuthContext);
   const navigate = useNavigate();
 
   const handleGuestSignIn = () => {
@@ -35,7 +35,6 @@ const Home: FC = () => {
 
   return (
     <Container maxWidth="sm">
-      {isSignedIn && <Navigate to={`/teams/${currentUser?.team_id}`} />}
       <Typography variant="h2" component="div" gutterBottom>
         DivWork
       </Typography>

--- a/frontend/src/pages/SignIn.tsx
+++ b/frontend/src/pages/SignIn.tsx
@@ -1,5 +1,5 @@
 import { FC, useContext, useState } from "react";
-import { Navigate, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import Cookies from "js-cookie";
 import { Button, Container, Grid, TextField, Typography } from "@mui/material";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
@@ -11,7 +11,7 @@ const SignIn: FC = () => {
   const [email, setEmail] = useState<string>("");
   const [password, setPassword] = useState<string>("");
 
-  const { isSignedIn, setIsSignedIn, currentUser } = useContext(AuthContext);
+  const { setIsSignedIn } = useContext(AuthContext);
   const navigate = useNavigate();
 
   const onClickSignIn = () => {
@@ -39,7 +39,6 @@ const SignIn: FC = () => {
 
   return (
     <Container maxWidth="sm">
-      {isSignedIn && <Navigate to={`/teams/${currentUser?.team_id}`} />}
       <Grid container direction="column" spacing={3}>
         <Grid item>
           <Typography variant="h4" component="div">

--- a/frontend/src/pages/TasksEdit.tsx
+++ b/frontend/src/pages/TasksEdit.tsx
@@ -1,5 +1,5 @@
 import { ChangeEvent, FC, useContext, useEffect, useState } from "react";
-import { Navigate, useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import Cookies from "js-cookie";
 import { Button, Container, Grid, TextField } from "@mui/material";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
@@ -13,7 +13,7 @@ import { DeadlineTextField } from "../components/DeadlineTextField";
 const TasksEdit: FC = () => {
   const params = useParams<{ id: string }>();
   const navigate = useNavigate();
-  const { isSignedIn, currentUser } = useContext(AuthContext);
+  const { currentUser } = useContext(AuthContext);
   const data = useFetchTask();
 
   const [task, setTask] = useState<editTask>({
@@ -67,7 +67,6 @@ const TasksEdit: FC = () => {
 
   return (
     <Container maxWidth="sm">
-      {isSignedIn || <Navigate to="/sign_in" />}
       <h1>タスクを編集する</h1>
       <Grid container direction="column" spacing={3}>
         <Grid item>

--- a/frontend/src/pages/TasksNew.tsx
+++ b/frontend/src/pages/TasksNew.tsx
@@ -1,5 +1,5 @@
 import { ChangeEvent, FC, useContext, useState } from "react";
-import { Navigate, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import Cookies from "js-cookie";
 import { Button, Container, Grid, TextField } from "@mui/material";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
@@ -10,7 +10,7 @@ import { PriorityTextField } from "../components/PriorityTextField";
 import { DeadlineTextField } from "../components/DeadlineTextField";
 
 const TasksNew: FC = () => {
-  const { isSignedIn, currentUser } = useContext(AuthContext);
+  const { currentUser } = useContext(AuthContext);
   const navigate = useNavigate();
 
   const [task, setTask] = useState<newTask>({
@@ -62,7 +62,6 @@ const TasksNew: FC = () => {
 
   return (
     <Container maxWidth="sm">
-      {isSignedIn || <Navigate to="/sign_in" />}
       <h1>タスクを作成する</h1>
       <Grid container direction="column" spacing={3}>
         <Grid item>

--- a/frontend/src/pages/TasksShow.tsx
+++ b/frontend/src/pages/TasksShow.tsx
@@ -1,16 +1,15 @@
 import { FC, useContext } from "react";
-import { Link, Navigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { Button, Container } from "@mui/material";
 import { useFetchTask } from "../hooks/useFetchTask";
 import { AuthContext } from "../providers/AuthProvider";
 
 const TasksShow: FC = () => {
   const task = useFetchTask();
-  const { isSignedIn, currentUser } = useContext(AuthContext);
+  const { currentUser } = useContext(AuthContext);
 
   return (
     <Container maxWidth="sm">
-      {isSignedIn || <Navigate to="/sign_in" />}
       <h1>タスク詳細</h1>
       <div>
         <h2>{task?.title}</h2>

--- a/frontend/src/pages/TeamsShow.tsx
+++ b/frontend/src/pages/TeamsShow.tsx
@@ -1,17 +1,15 @@
-import { useState, useEffect, FC, useContext } from "react";
-import { useParams, Link, Navigate } from "react-router-dom";
+import { useState, useEffect, FC } from "react";
+import { useParams, Link } from "react-router-dom";
 import Cookies from "js-cookie";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { axiosInstance } from "../utils/axios";
 import { Team, TeamsShowResponse, User } from "../types";
-import { AuthContext } from "../providers/AuthProvider";
 
 const TeamsShow: FC = () => {
   const [team, setTeam] = useState<Team>();
   const [users, setUsers] = useState<User[]>();
 
   const params = useParams<{ id: string }>();
-  const { isSignedIn } = useContext(AuthContext);
 
   const options: AxiosRequestConfig = {
     url: `/teams/${params.id}`,
@@ -38,7 +36,6 @@ const TeamsShow: FC = () => {
 
   return (
     <div>
-      {isSignedIn || <Navigate to="/sign_in" />}
       <h1>Teams#Show</h1>
       <h2>{team?.name}</h2>
       <div>

--- a/frontend/src/pages/UsersShow.tsx
+++ b/frontend/src/pages/UsersShow.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, FC, useContext } from "react";
-import { useParams, Link, Navigate } from "react-router-dom";
+import { useParams, Link } from "react-router-dom";
 import Cookies from "js-cookie";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { axiosInstance } from "../utils/axios";
@@ -10,7 +10,7 @@ const UsersShow: FC = () => {
   const [user, setUser] = useState<User>();
   const [tasks, setTasks] = useState<Task[]>([]);
 
-  const { isSignedIn, currentUser } = useContext(AuthContext);
+  const { currentUser } = useContext(AuthContext);
   const params = useParams<{ id: string }>();
 
   const options: AxiosRequestConfig = {
@@ -37,7 +37,6 @@ const UsersShow: FC = () => {
 
   return (
     <div>
-      {isSignedIn || <Navigate to="/sign_in" />}
       <h1>Users#Show</h1>
       <h2>{user?.name}</h2>
       {user?.id === currentUser?.id && (

--- a/frontend/src/providers/AuthProvider.tsx
+++ b/frontend/src/providers/AuthProvider.tsx
@@ -18,6 +18,8 @@ type Props = {
 };
 
 type AuthContextValue = {
+  loading: boolean;
+  setLoading: Dispatch<SetStateAction<boolean>>;
   isSignedIn: boolean;
   setIsSignedIn: Dispatch<SetStateAction<boolean>>;
   currentUser: User | undefined;
@@ -29,12 +31,27 @@ export const AuthContext = createContext<AuthContextValue>(
 );
 
 export const AuthProvider: FC<Props> = ({ children }) => {
+  const [loading, setLoading] = useState<boolean>(true);
   const [isSignedIn, setIsSignedIn] = useState<boolean>(false);
   const [currentUser, setCurrentUser] = useState<User | undefined>(undefined);
 
   const AuthProviderValue = useMemo(
-    () => ({ isSignedIn, setIsSignedIn, currentUser, setCurrentUser }),
-    [isSignedIn, setIsSignedIn, currentUser, setCurrentUser]
+    () => ({
+      loading,
+      setLoading,
+      isSignedIn,
+      setIsSignedIn,
+      currentUser,
+      setCurrentUser,
+    }),
+    [
+      loading,
+      setLoading,
+      isSignedIn,
+      setIsSignedIn,
+      currentUser,
+      setCurrentUser,
+    ]
   );
 
   const options: AxiosRequestConfig = {
@@ -55,8 +72,12 @@ export const AuthProvider: FC<Props> = ({ children }) => {
         if (res.data.is_signed_in === true) {
           setIsSignedIn(true);
           setCurrentUser(res.data.current_user);
-        } else {
+          setLoading(false);
+        } else if (res.data.is_signed_in === false) {
           setIsSignedIn(false);
+          setLoading(false);
+        } else {
+          setLoading(true);
         }
       })
       .catch((err) => console.log(err));

--- a/frontend/src/tests/PrivateRoute.test.tsx
+++ b/frontend/src/tests/PrivateRoute.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import PrivateRoute from "../components/PrivateRoute";
+import PublicRoute from "../components/PublicRoute";
+import SignIn from "../pages/SignIn";
+import TeamsShow from "../pages/TeamsShow";
+
+describe("PrivateRoute", () => {
+  test("ログインしていない状態でPrivateRouteにアクセスしない", async () => {
+    render(
+      <MemoryRouter initialEntries={["/teams/1"]}>
+        <Routes>
+          <Route
+            path="/sign_in"
+            element={
+              <PublicRoute>
+                <SignIn />
+              </PublicRoute>
+            }
+          />
+          <Route
+            path="/teams/:id"
+            element={
+              <PrivateRoute>
+                <TeamsShow />
+              </PrivateRoute>
+            }
+          />
+        </Routes>
+      </MemoryRouter>
+    );
+    await waitFor(() => {
+      expect(screen.queryByText("Teams#Show")).not.toBeInTheDocument();
+    });
+    expect(await screen.findByLabelText("メールアドレス")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/PublicRoute.test.tsx
+++ b/frontend/src/tests/PublicRoute.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen, waitFor } from "@testing-library/react";
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { rest } from "msw";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+// eslint-disable-next-line import/no-extraneous-dependencies
+import Header from "../components/Header";
+import PrivateRoute from "../components/PrivateRoute";
+import PublicRoute from "../components/PublicRoute";
+import { server } from "../mocks/server";
+import SignIn from "../pages/SignIn";
+import TeamsShow from "../pages/TeamsShow";
+import { AuthProvider } from "../providers/AuthProvider";
+
+describe("PublicRoute", () => {
+  test("ログイン状態でPablicRouteにアクセスしない", async () => {
+    server.use(
+      rest.get("/auth/sessions", (req, res, ctx) => {
+        return res(
+          ctx.status(200),
+          ctx.json({
+            is_signed_in: true,
+            current_user: {
+              email: "test@example.com",
+              uid: "test@example.com",
+              id: 1,
+              provider: "email",
+              allow_password_change: false,
+              name: "USER_1",
+              nickname: null,
+              image: null,
+              team_id: 1,
+            },
+          })
+        );
+      })
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/sign_in"]}>
+        <AuthProvider>
+          <Header />
+          <Routes>
+            <Route
+              path="/sign_in"
+              element={
+                <PublicRoute>
+                  <SignIn />
+                </PublicRoute>
+              }
+            />
+            <Route
+              path="/teams/:id"
+              element={
+                <PrivateRoute>
+                  <TeamsShow />
+                </PrivateRoute>
+              }
+            />
+          </Routes>
+        </AuthProvider>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByLabelText("メールアドレス")).not.toBeInTheDocument();
+    });
+    expect(await screen.findByText("Teams#Show")).toBeInTheDocument();
+    expect(await screen.findByText("USER_2")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/TeamsSelect.test.tsx
+++ b/frontend/src/tests/TeamsSelect.test.tsx
@@ -25,7 +25,7 @@ describe("TeamsSelect", () => {
     // eslint-disable-next-line testing-library/no-unnecessary-act
     act(() => {
       userEvent.click(teamInput);
-    })
+    });
 
     expect(await screen.findByText("TEAM_1")).toBeInTheDocument();
     expect(await screen.findByText("TEAM_2")).toBeInTheDocument();


### PR DESCRIPTION
### 問題
ログイン後にアクセスできるページへ遷移する際、認証情報がロード中のためログインしていないとみなし、トップページへ戻ってしまう。

### 原因
ログイン判定時、認証情報ロード中の状態を考慮していなかった。
ページ遷移のたびにHeaderが更新され、認証情報を保持出来ていなかった。

### 対応策
- Headerをmemo化し、ページ遷移の度にレンダリングしないようにする。
- 認証情報ロード中の状態を作成し、ロード中にログイン判定を実施しないようにする。

### 変更内容
-  `Header`の`memo`化
-  認証情報ロード中の状態`loading, setLoading`の作成
- `PublicRoute`, `PrivateRoute`の作成
-  ロード中はログイン判定を実施しないようロジック修正
-  `PublicRoute`, `PrivateRoute`のテスト作成