### PR TITLE
feat: muiコンポーネントの導入とレイアウト修正 #117

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ja">
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
@@ -28,7 +28,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>DivWork</title>
     <base href="/" />
   </head>
   <body>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,9 +1,6 @@
 import { BrowserRouter, Routes, Route } from "react-router-dom";
-import { css, Global } from "@emotion/react";
-import { Box } from "@mui/material";
 import { AuthProvider } from "./providers/AuthProvider";
 import Home from "./pages/Home";
-import Header from "./components/Header";
 import SignUp from "./pages/SignUp";
 import SignIn from "./pages/SignIn";
 import TeamsSelect from "./pages/TeamsSelect";
@@ -19,20 +16,13 @@ import "@fontsource/roboto/500.css";
 import "@fontsource/roboto/700.css";
 import PrivateRoute from "./components/PrivateRoute";
 import PublicRoute from "./components/PublicRoute";
+import CommonLayout from "./components/CommonLayout";
 
 const App: React.FC = () => {
-  const global = css`
-    * {
-      margin: 0;
-    }
-  `;
-
   return (
     <BrowserRouter>
-      <Global styles={global} />
       <AuthProvider>
-        <Header />
-        <Box m={2} pt={4}>
+        <CommonLayout>
           <Routes>
             <Route
               path="/"
@@ -115,7 +105,7 @@ const App: React.FC = () => {
               }
             />
           </Routes>
-        </Box>
+        </CommonLayout>
       </AuthProvider>
     </BrowserRouter>
   );

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -32,7 +32,7 @@ const App: React.FC = () => {
       <Global styles={global} />
       <AuthProvider>
         <Header />
-        <Box m={2} pt={3}>
+        <Box m={2} pt={4}>
           <Routes>
             <Route
               path="/"

--- a/frontend/src/components/CommonLayout.tsx
+++ b/frontend/src/components/CommonLayout.tsx
@@ -1,0 +1,33 @@
+import { css, Global } from "@emotion/react";
+import { Box, Container, Grid } from "@mui/material";
+import { FC } from "react";
+import { RouteProps } from "react-router-dom";
+import Header from "./Header";
+
+const CommonLayout: FC<RouteProps> = ({ children }) => {
+  const global = css`
+    * {
+      margin: 0;
+    }
+  `;
+
+  return (
+    <div>
+      <header>
+        <Header />
+      </header>
+      <main>
+        <Global styles={global} />
+        <Box m={2} pt={4}>
+          <Container maxWidth="lg">
+            <Grid container justifyContent="center">
+              <Grid item>{children}</Grid>
+            </Grid>
+          </Container>
+        </Box>
+      </main>
+    </div>
+  );
+};
+
+export default CommonLayout;

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -62,8 +62,8 @@ const Header: FC = memo(() => {
           >
             DivWork
           </Typography>
-          <>
-            {isSignedIn && (
+          <div>
+            {isSignedIn ? (
               <Box sx={{ flexGrow: 0, display: { xs: "flex" } }}>
                 <Button sx={{ my: 2, color: "white", display: "block" }}>
                   {currentUser?.name}
@@ -76,8 +76,7 @@ const Header: FC = memo(() => {
                   サインアウト
                 </Button>
               </Box>
-            )}
-            {isSignedIn || (
+            ) : (
               <Box sx={{ flexGrow: 0, display: { xs: "flex" } }}>
                 <Link
                   style={{ textDecoration: "none" }}
@@ -94,7 +93,7 @@ const Header: FC = memo(() => {
                 </Link>
               </Box>
             )}
-          </>
+          </div>
         </Toolbar>
       </Container>
     </AppBar>

--- a/frontend/src/components/PrivateRoute.tsx
+++ b/frontend/src/components/PrivateRoute.tsx
@@ -1,3 +1,4 @@
+import { Box, CircularProgress, Container } from "@mui/material";
 import { FC, useContext } from "react";
 import { Navigate, RouteProps } from "react-router-dom";
 import { AuthContext } from "../providers/AuthProvider";
@@ -12,7 +13,19 @@ const PrivateRoute: FC<RouteProps> = ({ children }) => {
     return <Navigate to="/sign_in" />;
   }
 
-  return <h5>Loading...</h5>;
+  return (
+    <Container maxWidth="sm">
+      <Box
+        mt={15}
+        sx={{
+          display: "flex",
+          justifyContent: "center",
+        }}
+      >
+        <CircularProgress />
+      </Box>
+    </Container>
+  );
 };
 
 export default PrivateRoute;

--- a/frontend/src/components/PublicRoute.tsx
+++ b/frontend/src/components/PublicRoute.tsx
@@ -1,3 +1,4 @@
+import { Box, CircularProgress, Container } from "@mui/material";
 import { FC, useContext } from "react";
 import { Navigate, RouteProps } from "react-router-dom";
 import { AuthContext } from "../providers/AuthProvider";
@@ -12,7 +13,19 @@ const PublicRoute: FC<RouteProps> = ({ children }) => {
     return <Navigate to={`/teams/${currentUser?.team_id}`} />;
   }
 
-  return <h5>Loading...</h5>;
+  return (
+    <Container maxWidth="sm">
+      <Box
+        mt={15}
+        sx={{
+          display: "flex",
+          justifyContent: "center",
+        }}
+      >
+        <CircularProgress />
+      </Box>
+    </Container>
+  );
 };
 
 export default PublicRoute;

--- a/frontend/src/pages/DivisionsNew.tsx
+++ b/frontend/src/pages/DivisionsNew.tsx
@@ -1,7 +1,7 @@
 import { ChangeEvent, FC, useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import Cookies from "js-cookie";
-import { Button, Container, Grid, TextField } from "@mui/material";
+import { Button, Container, Grid, TextField, Typography } from "@mui/material";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { axiosInstance } from "../utils/axios";
 import { divisionTask, TasksResponse, DivisionsCreateResponse } from "../types";
@@ -79,12 +79,17 @@ const DivisionsNew: FC = () => {
 
   return (
     <Container maxWidth="sm">
-      <h1>タスクを分担する</h1>
-      <Grid container direction="column" spacing={3}>
+      <Grid container direction="column" spacing={2}>
+        <Grid item>
+          <Typography variant="h4" component="div">
+            タスクを分担する
+          </Typography>
+        </Grid>
         <Grid item>
           <TextField
             label="タイトル"
             variant="standard"
+            sx={{ width: "30ch" }}
             name="title"
             value={task.title}
             onChange={handleInputChange}
@@ -93,9 +98,10 @@ const DivisionsNew: FC = () => {
         <Grid item>
           <TextField
             label="詳細"
-            variant="standard"
+            variant="outlined"
             multiline
-            rows={3}
+            rows={4}
+            sx={{ width: "55ch" }}
             name="description"
             value={task.description}
             onChange={handleInputChange}
@@ -129,6 +135,7 @@ const DivisionsNew: FC = () => {
           <TextField
             label="送信コメント"
             variant="standard"
+            sx={{ width: "50ch" }}
             value={comment}
             onChange={(event) => setComment(event.target.value)}
           />

--- a/frontend/src/pages/DivisionsNew.tsx
+++ b/frontend/src/pages/DivisionsNew.tsx
@@ -1,7 +1,7 @@
 import { ChangeEvent, FC, useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import Cookies from "js-cookie";
-import { Button, Container, Grid, TextField, Typography } from "@mui/material";
+import { Button, Grid, TextField, Typography } from "@mui/material";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { axiosInstance } from "../utils/axios";
 import { divisionTask, TasksResponse, DivisionsCreateResponse } from "../types";
@@ -78,7 +78,7 @@ const DivisionsNew: FC = () => {
   }, []);
 
   return (
-    <Container maxWidth="sm">
+    <div>
       <Grid container direction="column" spacing={2}>
         <Grid item>
           <Typography variant="h4" component="div">
@@ -150,7 +150,7 @@ const DivisionsNew: FC = () => {
           </Button>
         </Grid>
       </Grid>
-    </Container>
+    </div>
   );
 };
 

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -40,18 +40,24 @@ const Home: FC = () => {
       </Typography>
       <Grid container direction="column" spacing={2}>
         <Grid item>
-          <Link style={{ textDecoration: "none" }} to="/sign_up/teams/select">
-            <Button variant="contained" type="button">
-              サインアップ
-            </Button>
-          </Link>
+          <Button
+            variant="contained"
+            type="button"
+            component={Link}
+            to="/sign_up/teams/select"
+          >
+            サインアップ
+          </Button>
         </Grid>
         <Grid item>
-          <Link style={{ textDecoration: "none" }} to="/sign_in">
-            <Button variant="outlined" type="button">
-              サインイン
-            </Button>
-          </Link>
+          <Button
+            variant="outlined"
+            type="button"
+            component={Link}
+            to="/sign_in"
+          >
+            サインイン
+          </Button>
         </Grid>
         <Grid item>
           <Button color="secondary" type="button" onClick={handleGuestSignIn}>

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,7 +1,7 @@
 import { FC, useContext } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import Cookies from "js-cookie";
-import { Button, Container, Grid, Typography } from "@mui/material";
+import { Button, Grid, Typography } from "@mui/material";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { axiosInstance } from "../utils/axios";
 import { AuthResponse } from "../types";
@@ -34,7 +34,7 @@ const Home: FC = () => {
   };
 
   return (
-    <Container maxWidth="sm">
+    <div>
       <Typography variant="h2" component="div" gutterBottom>
         DivWork
       </Typography>
@@ -65,7 +65,7 @@ const Home: FC = () => {
           </Button>
         </Grid>
       </Grid>
-    </Container>
+    </div>
   );
 };
 

--- a/frontend/src/pages/SignIn.tsx
+++ b/frontend/src/pages/SignIn.tsx
@@ -1,7 +1,7 @@
 import { FC, useContext, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import Cookies from "js-cookie";
-import { Button, Container, Grid, TextField, Typography } from "@mui/material";
+import { Button, Grid, TextField, Typography } from "@mui/material";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { axiosInstance } from "../utils/axios";
 import { AuthContext } from "../providers/AuthProvider";
@@ -38,7 +38,7 @@ const SignIn: FC = () => {
   };
 
   return (
-    <Container maxWidth="sm">
+    <div>
       <Grid container direction="column" spacing={3}>
         <Grid item>
           <Typography variant="h4" component="div">
@@ -76,7 +76,7 @@ const SignIn: FC = () => {
           </Button>
         </Grid>
       </Grid>
-    </Container>
+    </div>
   );
 };
 

--- a/frontend/src/pages/SignUp.tsx
+++ b/frontend/src/pages/SignUp.tsx
@@ -1,7 +1,7 @@
 import { FC, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import Cookies from "js-cookie";
-import { Button, Container, Grid, TextField, Typography } from "@mui/material";
+import { Button, Grid, TextField, Typography } from "@mui/material";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { axiosInstance } from "../utils/axios";
 import { AuthResponse } from "../types/index";
@@ -49,7 +49,7 @@ const SignUp: FC = () => {
   };
 
   return (
-    <Container maxWidth="sm">
+    <div>
       <Grid container direction="column" spacing={3}>
         <Grid item>
           <Typography variant="h4" component="div">
@@ -97,7 +97,7 @@ const SignUp: FC = () => {
           </Button>
         </Grid>
       </Grid>
-    </Container>
+    </div>
   );
 };
 

--- a/frontend/src/pages/TasksEdit.tsx
+++ b/frontend/src/pages/TasksEdit.tsx
@@ -1,7 +1,7 @@
 import { ChangeEvent, FC, useContext, useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import Cookies from "js-cookie";
-import { Button, Container, Grid, TextField, Typography } from "@mui/material";
+import { Button, Grid, TextField, Typography } from "@mui/material";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { axiosInstance } from "../utils/axios";
 import { TasksResponse, editTask } from "../types";
@@ -66,7 +66,7 @@ const TasksEdit: FC = () => {
   }, [data]);
 
   return (
-    <Container maxWidth="sm">
+    <div>
       <Grid container direction="column" spacing={4}>
         <Grid item>
           <Typography variant="h4" component="div">
@@ -117,7 +117,7 @@ const TasksEdit: FC = () => {
           </Button>
         </Grid>
       </Grid>
-    </Container>
+    </div>
   );
 };
 

--- a/frontend/src/pages/TasksEdit.tsx
+++ b/frontend/src/pages/TasksEdit.tsx
@@ -1,7 +1,7 @@
 import { ChangeEvent, FC, useContext, useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import Cookies from "js-cookie";
-import { Button, Container, Grid, TextField } from "@mui/material";
+import { Button, Container, Grid, TextField, Typography } from "@mui/material";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { axiosInstance } from "../utils/axios";
 import { TasksResponse, editTask } from "../types";
@@ -67,12 +67,17 @@ const TasksEdit: FC = () => {
 
   return (
     <Container maxWidth="sm">
-      <h1>タスクを編集する</h1>
-      <Grid container direction="column" spacing={3}>
+      <Grid container direction="column" spacing={4}>
+        <Grid item>
+          <Typography variant="h4" component="div">
+            タスクを編集する
+          </Typography>
+        </Grid>
         <Grid item>
           <TextField
             label="タイトル"
             variant="standard"
+            sx={{ width: "30ch" }}
             name="title"
             value={task?.title}
             onChange={handleInputChange}
@@ -81,9 +86,10 @@ const TasksEdit: FC = () => {
         <Grid item>
           <TextField
             label="詳細"
-            variant="standard"
+            variant="outlined"
             multiline
-            rows={3}
+            rows={4}
+            sx={{ width: "55ch" }}
             name="description"
             value={task?.description}
             onChange={handleInputChange}

--- a/frontend/src/pages/TasksNew.tsx
+++ b/frontend/src/pages/TasksNew.tsx
@@ -1,7 +1,7 @@
 import { ChangeEvent, FC, useContext, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import Cookies from "js-cookie";
-import { Button, Container, Grid, TextField, Typography } from "@mui/material";
+import { Button, Grid, TextField, Typography } from "@mui/material";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { axiosInstance } from "../utils/axios";
 import { TasksResponse, newTask } from "../types";
@@ -61,7 +61,7 @@ const TasksNew: FC = () => {
   };
 
   return (
-    <Container maxWidth="sm">
+    <div>
       <Grid container direction="column" spacing={4}>
         <Grid item>
           <Typography variant="h4" component="div">
@@ -112,7 +112,7 @@ const TasksNew: FC = () => {
           </Button>
         </Grid>
       </Grid>
-    </Container>
+    </div>
   );
 };
 

--- a/frontend/src/pages/TasksNew.tsx
+++ b/frontend/src/pages/TasksNew.tsx
@@ -1,7 +1,7 @@
 import { ChangeEvent, FC, useContext, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import Cookies from "js-cookie";
-import { Button, Container, Grid, TextField } from "@mui/material";
+import { Button, Container, Grid, TextField, Typography } from "@mui/material";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { axiosInstance } from "../utils/axios";
 import { TasksResponse, newTask } from "../types";
@@ -62,12 +62,17 @@ const TasksNew: FC = () => {
 
   return (
     <Container maxWidth="sm">
-      <h1>タスクを作成する</h1>
-      <Grid container direction="column" spacing={3}>
+      <Grid container direction="column" spacing={4}>
+        <Grid item>
+          <Typography variant="h4" component="div">
+            タスクを作成する
+          </Typography>
+        </Grid>
         <Grid item>
           <TextField
             label="タイトル"
             variant="standard"
+            sx={{ width: "30ch" }}
             name="title"
             value={task.title}
             onChange={handleInputChange}
@@ -76,9 +81,10 @@ const TasksNew: FC = () => {
         <Grid item>
           <TextField
             label="詳細"
-            variant="standard"
+            variant="outlined"
             multiline
-            rows={3}
+            rows={4}
+            sx={{ width: "55ch" }}
             name="description"
             value={task.description}
             onChange={handleInputChange}

--- a/frontend/src/pages/TasksShow.tsx
+++ b/frontend/src/pages/TasksShow.tsx
@@ -32,26 +32,26 @@ const TasksShow: FC = () => {
       </div>
       {task?.user_id === currentUser?.id && (
         <div>
-          <Link
-            style={{ textDecoration: "none" }}
+          <Button
+            color="secondary"
+            type="button"
+            component={Link}
             to={`/tasks/${task?.id}/edit`}
           >
-            <Button color="secondary" type="button">
-              編集
-            </Button>
-          </Link>
+            編集
+          </Button>
         </div>
       )}
       <br />
       <div>
-        <Link
-          style={{ textDecoration: "none" }}
+        <Button
+          variant="contained"
+          type="button"
+          component={Link}
           to={`/tasks/${task?.id}/divisions/new`}
         >
-          <Button variant="contained" type="button">
-            分担する
-          </Button>
-        </Link>
+          分担する
+        </Button>
       </div>
     </Container>
   );

--- a/frontend/src/pages/TasksShow.tsx
+++ b/frontend/src/pages/TasksShow.tsx
@@ -1,6 +1,6 @@
 import { FC, useContext } from "react";
 import { Link } from "react-router-dom";
-import { Button, Container, Grid, Typography } from "@mui/material";
+import { Button, Grid, Typography } from "@mui/material";
 import { useFetchTask } from "../hooks/useFetchTask";
 import { AuthContext } from "../providers/AuthProvider";
 
@@ -9,7 +9,7 @@ const TasksShow: FC = () => {
   const { currentUser } = useContext(AuthContext);
 
   return (
-    <Container maxWidth="sm">
+    <div>
       <Grid container direction="column" spacing={2}>
         <Grid item>
           <Typography variant="h4" component="div">
@@ -80,7 +80,7 @@ const TasksShow: FC = () => {
           </Button>
         </Grid>
       </Grid>
-    </Container>
+    </div>
   );
 };
 

--- a/frontend/src/pages/TasksShow.tsx
+++ b/frontend/src/pages/TasksShow.tsx
@@ -1,6 +1,6 @@
 import { FC, useContext } from "react";
 import { Link } from "react-router-dom";
-import { Button, Container } from "@mui/material";
+import { Button, Container, Grid, Typography } from "@mui/material";
 import { useFetchTask } from "../hooks/useFetchTask";
 import { AuthContext } from "../providers/AuthProvider";
 
@@ -10,49 +10,76 @@ const TasksShow: FC = () => {
 
   return (
     <Container maxWidth="sm">
-      <h1>タスク詳細</h1>
-      <div>
-        <h2>{task?.title}</h2>
-      </div>
-      <div>
-        <h4>詳細</h4>
-        <p>{task?.description}</p>
-      </div>
-      <div>
-        <h4>納期</h4>
-        <p>{task?.deadline.toString()}</p>
-      </div>
-      <div>
-        <h4>優先度</h4>
-        <p>{task?.priority}</p>
-      </div>
-      <div>
-        <h4>完了フラグ</h4>
-        <p>{task?.is_done.toString()}</p>
-      </div>
-      {task?.user_id === currentUser?.id && (
-        <div>
+      <Grid container direction="column" spacing={2}>
+        <Grid item>
+          <Typography variant="h4" component="div">
+            タスク詳細
+          </Typography>
+        </Grid>
+        <Grid item>
+          <Typography variant="subtitle1" component="div">
+            タイトル
+          </Typography>
+          <Typography variant="h6" component="div">
+            {task?.title}
+          </Typography>
+        </Grid>
+        <Grid item>
+          <Typography variant="subtitle1" component="div">
+            詳細
+          </Typography>
+          <Typography variant="body1" component="div">
+            {task?.description}
+          </Typography>
+        </Grid>
+        <Grid item>
+          <Typography variant="subtitle1" component="div">
+            納期
+          </Typography>
+          <Typography variant="body1" component="div">
+            {task?.deadline.toString()}
+          </Typography>
+        </Grid>
+        <Grid item>
+          <Typography variant="subtitle1" component="div">
+            優先度
+          </Typography>
+          <Typography variant="body1" component="div">
+            {task?.priority}
+          </Typography>
+        </Grid>
+        <Grid item>
+          <Typography variant="subtitle1" component="div">
+            完了フラグ
+          </Typography>
+          <Typography variant="body1" component="div">
+            {task?.is_done.toString()}
+          </Typography>
+        </Grid>
+        {task?.user_id === currentUser?.id && (
+          <Grid item>
+            <Button
+              variant="outlined"
+              color="secondary"
+              type="button"
+              component={Link}
+              to={`/tasks/${task?.id}/edit`}
+            >
+              編集
+            </Button>
+          </Grid>
+        )}
+        <Grid item>
           <Button
-            color="secondary"
+            variant="contained"
             type="button"
             component={Link}
-            to={`/tasks/${task?.id}/edit`}
+            to={`/tasks/${task?.id}/divisions/new`}
           >
-            編集
+            分担する
           </Button>
-        </div>
-      )}
-      <br />
-      <div>
-        <Button
-          variant="contained"
-          type="button"
-          component={Link}
-          to={`/tasks/${task?.id}/divisions/new`}
-        >
-          分担する
-        </Button>
-      </div>
+        </Grid>
+      </Grid>
     </Container>
   );
 };

--- a/frontend/src/pages/TeamsSelect.tsx
+++ b/frontend/src/pages/TeamsSelect.tsx
@@ -1,13 +1,6 @@
 import { ChangeEvent, FC, useContext, useEffect, useState } from "react";
 import { Link, Navigate } from "react-router-dom";
-import {
-  Button,
-  Container,
-  Grid,
-  MenuItem,
-  TextField,
-  Typography,
-} from "@mui/material";
+import { Button, Grid, MenuItem, TextField, Typography } from "@mui/material";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { axiosInstance } from "../utils/axios";
 import { Team, TeamsSelectResponse } from "../types";
@@ -52,7 +45,7 @@ const TeamsSelect: FC = () => {
   };
 
   return (
-    <Container maxWidth="sm">
+    <div>
       {isSignedIn && <Navigate to={`/teams/${currentUser?.team_id}`} />}
       <Grid container direction="column" spacing={3}>
         <Grid item>
@@ -93,7 +86,7 @@ const TeamsSelect: FC = () => {
           </Link>
         </Grid>
       </Grid>
-    </Container>
+    </div>
   );
 };
 

--- a/frontend/src/pages/TeamsShow.tsx
+++ b/frontend/src/pages/TeamsShow.tsx
@@ -40,7 +40,7 @@ const TeamsShow: FC = () => {
       <Grid container direction="column" spacing={3}>
         <Grid item>
           <Typography variant="h4" component="div">
-            {team?.name}のタスク
+            {team?.name ? `${team.name}のタスク` : ""}
           </Typography>
         </Grid>
         <Grid item>

--- a/frontend/src/pages/TeamsShow.tsx
+++ b/frontend/src/pages/TeamsShow.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, FC } from "react";
-import { useParams, Link } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import Cookies from "js-cookie";
+import { Button, Container, Grid, Typography } from "@mui/material";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { axiosInstance } from "../utils/axios";
 import { Team, TeamsShowResponse, User } from "../types";
@@ -35,24 +36,27 @@ const TeamsShow: FC = () => {
   }, []);
 
   return (
-    <div>
-      <h1>Teams#Show</h1>
-      <h2>{team?.name}</h2>
-      <div>
-        <ul>
+    <Container maxWidth="sm">
+      <Grid container direction="column" spacing={3}>
+        <Grid item>
+          <Typography variant="h4" component="div">
+            {team?.name}のタスク
+          </Typography>
+        </Grid>
+        <Grid item>
           {users?.map((user) => (
-            <div key={user.id}>
-              <Link to={`/users/${user.id}`}>
-                <li>{user.name}</li>
-              </Link>
+            <Grid item key={user.id}>
+              <Button variant="text" size="large" href={`/users/${user.id}`}>
+                {user.name}
+              </Button>
               {user.tasks_count[0]}
               {user.tasks_count[1]}
               {user.tasks_count[2]}
-            </div>
+            </Grid>
           ))}
-        </ul>
-      </div>
-    </div>
+        </Grid>
+      </Grid>
+    </Container>
   );
 };
 

--- a/frontend/src/pages/TeamsShow.tsx
+++ b/frontend/src/pages/TeamsShow.tsx
@@ -39,7 +39,7 @@ const TeamsShow: FC = () => {
     <div>
       <Grid container direction="column" spacing={3}>
         <Grid item>
-          <Typography variant="h4" component="div">
+          <Typography variant="h4" component="div" data-testid="teams-show-h4">
             {team?.name ? `${team.name}のタスク` : ""}
           </Typography>
         </Grid>

--- a/frontend/src/pages/TeamsShow.tsx
+++ b/frontend/src/pages/TeamsShow.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, FC } from "react";
-import { useParams } from "react-router-dom";
+import { useParams, Link } from "react-router-dom";
 import Cookies from "js-cookie";
 import { Button, Container, Grid, Typography } from "@mui/material";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
@@ -46,7 +46,12 @@ const TeamsShow: FC = () => {
         <Grid item>
           {users?.map((user) => (
             <Grid item key={user.id}>
-              <Button variant="text" size="large" href={`/users/${user.id}`}>
+              <Button
+                variant="text"
+                size="large"
+                component={Link}
+                to={`/users/${user.id}`}
+              >
                 {user.name}
               </Button>
               {user.tasks_count[0]}

--- a/frontend/src/pages/TeamsShow.tsx
+++ b/frontend/src/pages/TeamsShow.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, FC } from "react";
 import { useParams, Link } from "react-router-dom";
 import Cookies from "js-cookie";
-import { Button, Container, Grid, Typography } from "@mui/material";
+import { Button, Grid, Typography } from "@mui/material";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { axiosInstance } from "../utils/axios";
 import { Team, TeamsShowResponse, User } from "../types";
@@ -36,7 +36,7 @@ const TeamsShow: FC = () => {
   }, []);
 
   return (
-    <Container maxWidth="sm">
+    <div>
       <Grid container direction="column" spacing={3}>
         <Grid item>
           <Typography variant="h4" component="div">
@@ -61,7 +61,7 @@ const TeamsShow: FC = () => {
           ))}
         </Grid>
       </Grid>
-    </Container>
+    </div>
   );
 };
 

--- a/frontend/src/pages/UsersShow.tsx
+++ b/frontend/src/pages/UsersShow.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, FC, useContext } from "react";
 import { useParams, Link } from "react-router-dom";
 import Cookies from "js-cookie";
-import { Button, Container, Grid, Typography } from "@mui/material";
+import { Button, Grid, Typography } from "@mui/material";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { axiosInstance } from "../utils/axios";
 import { User, Task, UsersShowResponse } from "../types";
@@ -37,7 +37,7 @@ const UsersShow: FC = () => {
   }, []);
 
   return (
-    <Container maxWidth="sm">
+    <div>
       <Grid container direction="column" spacing={3}>
         <Grid item>
           <Typography variant="h4" component="div">
@@ -64,7 +64,7 @@ const UsersShow: FC = () => {
           ))}
         </Grid>
       </Grid>
-    </Container>
+    </div>
   );
 };
 

--- a/frontend/src/pages/UsersShow.tsx
+++ b/frontend/src/pages/UsersShow.tsx
@@ -41,7 +41,7 @@ const UsersShow: FC = () => {
       <Grid container direction="column" spacing={3}>
         <Grid item>
           <Typography variant="h4" component="div">
-            {user?.name}のタスク
+            {user?.name ? `${user.name}のタスク` : ""}
           </Typography>
         </Grid>
         {user?.id === currentUser?.id && (

--- a/frontend/src/pages/UsersShow.tsx
+++ b/frontend/src/pages/UsersShow.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, FC, useContext } from "react";
 import { useParams, Link } from "react-router-dom";
 import Cookies from "js-cookie";
+import { Button, Container, Grid, Typography } from "@mui/material";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { axiosInstance } from "../utils/axios";
 import { User, Task, UsersShowResponse } from "../types";
@@ -36,26 +37,34 @@ const UsersShow: FC = () => {
   }, []);
 
   return (
-    <div>
-      <h1>Users#Show</h1>
-      <h2>{user?.name}</h2>
-      {user?.id === currentUser?.id && (
-        <div>
-          <Link to="/tasks/new">
-            <button type="button">新規作成</button>
-          </Link>
-        </div>
-      )}
-      <div>
-        <ul>
+    <Container maxWidth="sm">
+      <Grid container direction="column" spacing={3}>
+        <Grid item>
+          <Typography variant="h4" component="div">
+            {user?.name}のタスク
+          </Typography>
+        </Grid>
+        {user?.id === currentUser?.id && (
+          <Grid item>
+            <Button
+              variant="contained"
+              type="button"
+              component={Link}
+              to="/tasks/new"
+            >
+              新規作成
+            </Button>
+          </Grid>
+        )}
+        <Grid item>
           {tasks?.map((task) => (
-            <Link to={`/tasks/${task.id}`} key={task.id}>
-              <li>{task.title}</li>
-            </Link>
+            <Grid item key={task.id}>
+              <Link to={`/tasks/${task.id}`}>{task.title}</Link>
+            </Grid>
           ))}
-        </ul>
-      </div>
-    </div>
+        </Grid>
+      </Grid>
+    </Container>
   );
 };
 

--- a/frontend/src/tests/PrivateRoute.test.tsx
+++ b/frontend/src/tests/PrivateRoute.test.tsx
@@ -30,7 +30,7 @@ describe("PrivateRoute", () => {
       </MemoryRouter>
     );
     await waitFor(() => {
-      expect(screen.queryByText("Teams#Show")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("teams-show-h4")).not.toBeInTheDocument();
     });
     expect(await screen.findByLabelText("メールアドレス")).toBeInTheDocument();
   });

--- a/frontend/src/tests/PublicRoute.test.tsx
+++ b/frontend/src/tests/PublicRoute.test.tsx
@@ -64,7 +64,7 @@ describe("PublicRoute", () => {
     await waitFor(() => {
       expect(screen.queryByLabelText("メールアドレス")).not.toBeInTheDocument();
     });
-    expect(await screen.findByText("Teams#Show")).toBeInTheDocument();
+    expect(await screen.findByTestId("teams-show-h4")).toBeInTheDocument();
     expect(await screen.findByText("USER_2")).toBeInTheDocument();
   });
 });

--- a/frontend/src/tests/__snapshots__/Header.test.tsx.snap
+++ b/frontend/src/tests/__snapshots__/Header.test.tsx.snap
@@ -16,69 +16,71 @@ exports[`Header スナップショット 1`] = `
       >
         DivWork
       </a>
-      <div
-        className="MuiBox-root css-7ln23k"
-      >
-        <a
-          href="/sign_up/teams/select"
-          onClick={[Function]}
-          style={
-            Object {
-              "textDecoration": "none",
-            }
-          }
+      <div>
+        <div
+          className="MuiBox-root css-7ln23k"
         >
-          <button
-            className="MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButtonBase-root  css-1q39md6-MuiButtonBase-root-MuiButton-root"
-            disabled={false}
-            onBlur={[Function]}
-            onContextMenu={[Function]}
-            onDragLeave={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            tabIndex={0}
-            type="button"
-          >
-            サインアップ
-          </button>
-        </a>
-        <a
-          href="/sign_in"
-          onClick={[Function]}
-          style={
-            Object {
-              "textDecoration": "none",
+          <a
+            href="/sign_up/teams/select"
+            onClick={[Function]}
+            style={
+              Object {
+                "textDecoration": "none",
+              }
             }
-          }
-        >
-          <button
-            className="MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButtonBase-root  css-1q39md6-MuiButtonBase-root-MuiButton-root"
-            disabled={false}
-            onBlur={[Function]}
-            onContextMenu={[Function]}
-            onDragLeave={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            tabIndex={0}
-            type="button"
           >
-            サインイン
-          </button>
-        </a>
+            <button
+              className="MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButtonBase-root  css-1q39md6-MuiButtonBase-root-MuiButton-root"
+              disabled={false}
+              onBlur={[Function]}
+              onContextMenu={[Function]}
+              onDragLeave={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              tabIndex={0}
+              type="button"
+            >
+              サインアップ
+            </button>
+          </a>
+          <a
+            href="/sign_in"
+            onClick={[Function]}
+            style={
+              Object {
+                "textDecoration": "none",
+              }
+            }
+          >
+            <button
+              className="MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButtonBase-root  css-1q39md6-MuiButtonBase-root-MuiButton-root"
+              disabled={false}
+              onBlur={[Function]}
+              onContextMenu={[Function]}
+              onDragLeave={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              tabIndex={0}
+              type="button"
+            >
+              サインイン
+            </button>
+          </a>
+        </div>
       </div>
     </div>
   </div>

--- a/frontend/src/tests/__snapshots__/Home.test.tsx.snap
+++ b/frontend/src/tests/__snapshots__/Home.test.tsx.snap
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Home スナップショット 1`] = `
-<div
-  className="MuiContainer-root MuiContainer-maxWidthSm css-cuefkz-MuiContainer-root"
->
+<div>
   <div
     className="MuiTypography-root MuiTypography-h2 MuiTypography-gutterBottom css-i1hrn3-MuiTypography-root"
   >
@@ -16,68 +14,50 @@ exports[`Home スナップショット 1`] = `
       className="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
     >
       <a
+        className="MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root  css-sghohy-MuiButtonBase-root-MuiButton-root"
         href="/sign_up/teams/select"
+        onBlur={[Function]}
         onClick={[Function]}
-        style={
-          Object {
-            "textDecoration": "none",
-          }
-        }
+        onContextMenu={[Function]}
+        onDragLeave={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
+        tabIndex={0}
+        type="button"
       >
-        <button
-          className="MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root  css-sghohy-MuiButtonBase-root-MuiButton-root"
-          disabled={false}
-          onBlur={[Function]}
-          onContextMenu={[Function]}
-          onDragLeave={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-          onTouchEnd={[Function]}
-          onTouchMove={[Function]}
-          onTouchStart={[Function]}
-          tabIndex={0}
-          type="button"
-        >
-          サインアップ
-        </button>
+        サインアップ
       </a>
     </div>
     <div
       className="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
     >
       <a
+        className="MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButtonBase-root  css-1rwt2y5-MuiButtonBase-root-MuiButton-root"
         href="/sign_in"
+        onBlur={[Function]}
         onClick={[Function]}
-        style={
-          Object {
-            "textDecoration": "none",
-          }
-        }
+        onContextMenu={[Function]}
+        onDragLeave={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
+        tabIndex={0}
+        type="button"
       >
-        <button
-          className="MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButtonBase-root  css-1rwt2y5-MuiButtonBase-root-MuiButton-root"
-          disabled={false}
-          onBlur={[Function]}
-          onContextMenu={[Function]}
-          onDragLeave={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-          onTouchEnd={[Function]}
-          onTouchMove={[Function]}
-          onTouchStart={[Function]}
-          tabIndex={0}
-          type="button"
-        >
-          サインイン
-        </button>
+        サインイン
       </a>
     </div>
     <div

--- a/frontend/src/tests/__snapshots__/SignIn.test.tsx.snap
+++ b/frontend/src/tests/__snapshots__/SignIn.test.tsx.snap
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SignIn スナップショット 1`] = `
-<div
-  className="MuiContainer-root MuiContainer-maxWidthSm css-cuefkz-MuiContainer-root"
->
+<div>
   <div
     className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-3 MuiGrid-direction-xs-column css-32q0xd-MuiGrid-root"
   >

--- a/frontend/src/tests/__snapshots__/TeamsSelect.test.tsx.snap
+++ b/frontend/src/tests/__snapshots__/TeamsSelect.test.tsx.snap
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TeamsSelect スナップショット 1`] = `
-<div
-  className="MuiContainer-root MuiContainer-maxWidthSm css-cuefkz-MuiContainer-root"
->
+<div>
   <div
     className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-3 MuiGrid-direction-xs-column css-32q0xd-MuiGrid-root"
   >


### PR DESCRIPTION
### 目的
- 各ページのレイアウトを統一する。
- muiコンポーネントを使用してUIを向上させる。

### 変更内容
- 既存のページに`mui`コンポーネントを導入
- 共通レイアウト`CommonLayout.tsx`の作成と導入
- html ファイルの修正
- テストの修正