### PR TITLE
feat: 分担タスクのユーザー選択フォーム作成 #121

### DIFF
--- a/backend/app/controllers/api/v1/divisions_controller.rb
+++ b/backend/app/controllers/api/v1/divisions_controller.rb
@@ -5,7 +5,8 @@ class Api::V1::DivisionsController < ApplicationController
     task = Task.find(params[:task_id])
     new_task = task.dup
     new_task.parent = task
-    render json: { task: new_task }, status: :ok
+    team_members = task.user.team_members
+    render json: { task: new_task, team_members: }, status: :ok
   end
 
   def create

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -28,4 +28,8 @@ class User < ApplicationRecord
       user.team_id = 1
     end
   end
+
+  def team_members
+    team.users.where.not(id:)
+  end
 end

--- a/backend/spec/models/user_spec.rb
+++ b/backend/spec/models/user_spec.rb
@@ -78,4 +78,17 @@ RSpec.describe User, type: :model do
       expect(user.email).to eq "guest@example.com"
     end
   end
+
+  describe "team_members method" do
+    let!(:user_a) { create(:user, team:) }
+    let!(:user_b) { create(:user, team:) }
+
+    it "チームメンバーはuser_bであること" do
+      expect(user_a.team_members.first).to eq user_b
+    end
+
+    it "チームメンバーにuser_aが含まれないこと" do
+      expect(user_a.team_members).not_to include(user_a)
+    end
+  end
 end

--- a/backend/spec/requests/api/v1/divisions_spec.rb
+++ b/backend/spec/requests/api/v1/divisions_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe "Api::V1::Divisions", type: :request do
   let(:team) { create(:team) }
   let(:user_a) { create(:user, team:) }
+  let!(:user_b) { create(:user, team:) }
   let(:task) { create(:task, user: user_a) }
   let(:headers) { user_a.create_new_auth_token }
   let(:json) { JSON.parse(response.body) }
@@ -20,10 +21,13 @@ RSpec.describe "Api::V1::Divisions", type: :request do
     it "元のタスクIDが紐付いていること" do
       expect(json["task"]["parent_id"]).to eq task.id
     end
+
+    it "チームメンバーがuser_bであること" do
+      expect(json["team_members"][0]["id"]).to eq user_b.id
+    end
   end
 
   describe "POST /" do
-    let(:user_b) { create(:user, team:) }
     let(:task_params) { attributes_for(:task, user_id: user_b.id, parent_id: task.id) }
     let(:division_params) { attributes_for(:division) }
 

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -42,6 +42,12 @@ module.exports = {
       "ignorePackages",
       { js: "never", jsx: "never", ts: "never", tsx: "never" },
     ],
+    "import/no-extraneous-dependencies": [
+      "error",
+      {
+        devDependencies: ["**/tests/**", "**/mocks/**"],
+      },
+    ],
     "import/prefer-default-export": "off",
     "jsx-a11y/label-has-associated-control": [
       "error",

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { rest } from "msw";
 import { mockSignIn, mockAuthSessions } from "./mockAuth";
 import { mockTeam } from "./mockTeam";

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -1,5 +1,6 @@
 import { rest } from "msw";
 import { mockSignIn, mockAuthSessions } from "./mockAuth";
+import { mockDivisionCreate, mockDivisionNew } from "./mockDivision";
 import { mockTeam } from "./mockTeam";
 import { mockTeams } from "./mockTeams";
 import { mockUser, mockUserEdit } from "./mockUser";
@@ -8,7 +9,9 @@ export const handlers = [
   rest.get("/teams/select", mockTeams),
   rest.post("/auth/sign_in", mockSignIn),
   rest.get("/auth/sessions", mockAuthSessions),
-  rest.get(`/teams/:id`, mockTeam),
-  rest.get(`/users/:id`, mockUser),
-  rest.patch(`/auth`, mockUserEdit),
+  rest.get("/teams/:id", mockTeam),
+  rest.get("/users/:id", mockUser),
+  rest.patch("/auth", mockUserEdit),
+  rest.get("/tasks/:id/divisions/new", mockDivisionNew),
+  rest.post("/tasks/:id/divisions", mockDivisionCreate),
 ];

--- a/frontend/src/mocks/mockAuth.ts
+++ b/frontend/src/mocks/mockAuth.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { MockedRequest, ResponseResolver, restContext } from "msw";
 
 export const mockSignIn: ResponseResolver<MockedRequest, typeof restContext> = (

--- a/frontend/src/mocks/mockDivision.ts
+++ b/frontend/src/mocks/mockDivision.ts
@@ -1,0 +1,70 @@
+import { MockedRequest, ResponseResolver, restContext } from "msw";
+
+export const mockDivisionNew: ResponseResolver<
+  MockedRequest,
+  typeof restContext
+> = (req, res, ctx) => {
+  return res(
+    ctx.status(200),
+    ctx.json({
+      task: {
+        id: null,
+        title: "TASK_3",
+        description: "DIVISION",
+        deadline: "2022-06-12T13:16:00.000+09:00",
+        priority: "medium",
+        is_done: false,
+        user_id: 1,
+        created_at: "2022-06-09T21:26:46.537+09:00",
+        updated_at: "2022-06-09T21:26:46.537+09:00",
+        parent_id: 1,
+      },
+      team_members: [
+        {
+          id: 2,
+          provider: "email",
+          uid: "test2@example.com",
+          allow_password_change: false,
+          name: "USER_2",
+          nickname: null,
+          image: null,
+          email: "test2@example.com",
+          team_id: 1,
+          created_at: "2022-06-05T10:16:09.882+09:00",
+          updated_at: "2022-06-05T10:16:09.882+09:00",
+        },
+      ],
+    })
+  );
+};
+
+export const mockDivisionCreate: ResponseResolver<
+  MockedRequest,
+  typeof restContext
+> = (req, res, ctx) => {
+  return res(
+    ctx.status(200),
+    ctx.json({
+      task: {
+        id: 3,
+        title: "TASK_3",
+        description: "DIVISION",
+        deadline: "2022-06-12T13:16:00.000+09:00",
+        priority: "medium",
+        is_done: false,
+        user_id: 2,
+        created_at: "2022-06-09T21:26:46.537+09:00",
+        updated_at: "2022-06-09T21:26:46.537+09:00",
+        parent_id: 1,
+      },
+      division: {
+        id: 1,
+        user_id: 1,
+        task_id: 3,
+        created_at: "2022-07-03T12:00:17.069+09:00",
+        updated_at: "2022-07-03T12:00:17.069+09:00",
+        comment: "Thank you",
+      },
+    })
+  );
+};

--- a/frontend/src/mocks/mockTeam.ts
+++ b/frontend/src/mocks/mockTeam.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { MockedRequest, ResponseResolver, restContext } from "msw";
 
 export const mockTeam: ResponseResolver<MockedRequest, typeof restContext> = (

--- a/frontend/src/mocks/mockTeams.ts
+++ b/frontend/src/mocks/mockTeams.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { MockedRequest, ResponseResolver, restContext } from "msw";
 
 export const mockTeams: ResponseResolver<MockedRequest, typeof restContext> = (

--- a/frontend/src/mocks/mockUser.ts
+++ b/frontend/src/mocks/mockUser.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { MockedRequest, ResponseResolver, restContext } from "msw";
 
 export const mockUser: ResponseResolver<MockedRequest, typeof restContext> = (

--- a/frontend/src/mocks/server.ts
+++ b/frontend/src/mocks/server.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { setupServer } from "msw/node";
 import { handlers } from "./handlers";
 

--- a/frontend/src/pages/DivisionsNew.tsx
+++ b/frontend/src/pages/DivisionsNew.tsx
@@ -167,6 +167,7 @@ const DivisionsNew: FC = () => {
         </Grid>
         <Grid item>
           <Button
+            data-testid="send-button"
             variant="contained"
             type="submit"
             onClick={handleDivisionsCreate}

--- a/frontend/src/tests/DivisionsNew.test.tsx
+++ b/frontend/src/tests/DivisionsNew.test.tsx
@@ -1,0 +1,71 @@
+/* eslint-disable testing-library/no-unnecessary-act */
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { rest } from "msw";
+import { act } from "react-dom/test-utils";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import Header from "../components/Header";
+import { server } from "../mocks/server";
+import { AuthProvider } from "../providers/AuthProvider";
+import DivisionsNew from "../pages/DivisionsNew";
+import UsersShow from "../pages/UsersShow";
+
+describe("DivisionsNew", () => {
+  test("分担作成ページ", async () => {
+    server.use(
+      rest.get("/auth/sessions", (req, res, ctx) => {
+        return res(
+          ctx.status(200),
+          ctx.json({
+            is_signed_in: true,
+            current_user: {
+              email: "test@example.com",
+              uid: "test@example.com",
+              id: 1,
+              provider: "email",
+              allow_password_change: false,
+              name: "USER_1",
+              nickname: null,
+              image: null,
+              team_id: 1,
+            },
+          })
+        );
+      })
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/tasks/1/divisions/new"]}>
+        <AuthProvider>
+          <Header />
+          <Routes>
+            <Route path="/users/:id" element={<UsersShow />} />
+            <Route path="/tasks/:id/divisions/new" element={<DivisionsNew />} />
+          </Routes>
+        </AuthProvider>
+      </MemoryRouter>
+    );
+
+    // タスクが表示される
+    expect(await screen.findByDisplayValue("TASK_3")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByText("USER_2")).not.toBeInTheDocument();
+    });
+
+    act(() => {
+      userEvent.click(screen.getByLabelText("送信先ユーザー"));
+    });
+
+    // チームメンバーが表示される
+    expect(await screen.findByText("USER_2")).toBeInTheDocument();
+
+    act(() => {
+      userEvent.click(screen.getByText("USER_2"));
+      userEvent.type(screen.getByLabelText("送信コメント"), "Thank you");
+      userEvent.click(screen.getByTestId("send-button"));
+    });
+
+    // UsersShowページに遷移する
+    expect(await screen.findByTestId("users-show-h4")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/Header.test.tsx
+++ b/frontend/src/tests/Header.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import renderer from "react-test-renderer"; // eslint-disable-line import/no-extraneous-dependencies
+import renderer from "react-test-renderer";
 import { act } from "react-dom/test-utils";
 import { BrowserRouter } from "react-router-dom";
 import Header from "../components/Header";

--- a/frontend/src/tests/Home.test.tsx
+++ b/frontend/src/tests/Home.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import renderer from "react-test-renderer"; // eslint-disable-line import/no-extraneous-dependencies
+import renderer from "react-test-renderer";
 import { BrowserRouter } from "react-router-dom";
 import Home from "../pages/Home";
 

--- a/frontend/src/tests/PublicRoute.test.tsx
+++ b/frontend/src/tests/PublicRoute.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen, waitFor } from "@testing-library/react";
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { rest } from "msw";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import PrivateRoute from "../components/PrivateRoute";

--- a/frontend/src/tests/SignIn.test.tsx
+++ b/frontend/src/tests/SignIn.test.tsx
@@ -1,4 +1,4 @@
-import renderer from "react-test-renderer"; // eslint-disable-line import/no-extraneous-dependencies
+import renderer from "react-test-renderer";
 import { BrowserRouter } from "react-router-dom";
 import SignIn from "../pages/SignIn";
 

--- a/frontend/src/tests/TeamsSelect.test.tsx
+++ b/frontend/src/tests/TeamsSelect.test.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import renderer from "react-test-renderer";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/frontend/src/tests/UsersEdit.test.tsx
+++ b/frontend/src/tests/UsersEdit.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { rest } from "msw";
 import { act } from "react-dom/test-utils";
 import { MemoryRouter, Route, Routes } from "react-router-dom";

--- a/frontend/src/tests/UsersShow.test.tsx
+++ b/frontend/src/tests/UsersShow.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { rest } from "msw";
 import { act } from "react-dom/test-utils";
 import { MemoryRouter, Route, Routes } from "react-router-dom";

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -58,7 +58,6 @@ export type editTask = {
 export type divisionTask = {
   title: string;
   description: string;
-  user_id: number;
   parent_id: number;
 };
 
@@ -92,6 +91,11 @@ export type UsersResponse = {
 
 export type TasksResponse = {
   task: Task;
+};
+
+export type DivisionsNewResponse = {
+  task: Task;
+  team_members: User[];
 };
 
 export type DivisionsCreateResponse = {


### PR DESCRIPTION
### 変更内容
- `team_members`メソッドの追加
- `divisions#new`のレスポンスデータに`team_members`を追加
- `DivisionsNew`ページにユーザー選択フォームを追加
- テスト作成