### PR TITLE
feat: サクセス/エラーメッセージの作成 #124

### DIFF
--- a/backend/app/controllers/api/v1/divisions_controller.rb
+++ b/backend/app/controllers/api/v1/divisions_controller.rb
@@ -22,7 +22,7 @@ class Api::V1::DivisionsController < ApplicationController
 
     render json: { task: new_task, division: }, status: :ok
   rescue StandardError => e
-    render json: { error: e, message: "Failed to divide task" }, status: :internal_server_error
+    render json: { error: e, messages: error_messages(new_task) }, status: :internal_server_error
   end
 
   private

--- a/backend/app/controllers/api/v1/tasks_controller.rb
+++ b/backend/app/controllers/api/v1/tasks_controller.rb
@@ -8,7 +8,7 @@ class Api::V1::TasksController < ApplicationController
     if task.save
       render json: { task: }, status: :created
     else
-      render json: { message: "Failed to create task" }, status: :internal_server_error
+      render json: { messages: error_messages(task) }, status: :internal_server_error
     end
   end
 
@@ -20,7 +20,7 @@ class Api::V1::TasksController < ApplicationController
     if @task.update(task_params)
       render json: { task: @task }, status: :ok
     else
-      render json: { message: "Failed to update task" }, status: :internal_server_error
+      render json: { messages: error_messages(@task) }, status: :internal_server_error
     end
   end
 
@@ -28,7 +28,7 @@ class Api::V1::TasksController < ApplicationController
     if @task.destroy
       render json: { task: @task }, status: :ok
     else
-      render json: { message: "Failed to destroy task" }, status: :internal_server_error
+      render json: { messages: error_messages(@task) }, status: :internal_server_error
     end
   end
 
@@ -40,7 +40,7 @@ class Api::V1::TasksController < ApplicationController
 
   def ensure_correct_user
     if @task.user != current_api_v1_user
-      render json: { message: "User is wrong" }, status: :internal_server_error
+      render json: { messages: "この操作は出来ません" }, status: :internal_server_error
     end
   end
 

--- a/backend/app/controllers/application_controller.rb
+++ b/backend/app/controllers/application_controller.rb
@@ -1,3 +1,7 @@
 class ApplicationController < ActionController::API
   include DeviseTokenAuth::Concerns::SetUserByToken
+
+  def error_messages(obj)
+    obj.errors.full_messages
+  end
 end

--- a/backend/config/locales/ja.yml
+++ b/backend/config/locales/ja.yml
@@ -16,5 +16,6 @@ ja:
         deadline: 納期
         priority: 優先度
         is_done: 完了済み
+        user: ユーザー
       division:
         comment: コメント

--- a/backend/spec/requests/api/v1/divisions_spec.rb
+++ b/backend/spec/requests/api/v1/divisions_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe "Api::V1::Divisions", type: :request do
 
   describe "POST /" do
     let(:task_params) { attributes_for(:task, user_id: user_b.id, parent_id: task.id) }
+    let(:task_params_blank) { attributes_for(:task, parent_id: task.id) }
     let(:division_params) { attributes_for(:division) }
 
     before do
@@ -51,6 +52,14 @@ RSpec.describe "Api::V1::Divisions", type: :request do
            params: { task: task_params, division: division_params }.to_json,
            headers: headers
       expect(json["division"]["comment"]).to eq division_params[:comment]
+    end
+
+    it "ユーザーを入力しないとエラーメッセージが返ってくること" do
+      post "/api/v1/tasks/#{task.id}/divisions",
+           params: { task: task_params_blank, division: division_params }.to_json,
+           headers: headers
+      expect(response).to have_http_status(:internal_server_error)
+      expect(json["messages"][0]).to eq "ユーザーを入力してください"
     end
   end
 end

--- a/backend/spec/requests/api/v1/tasks_spec.rb
+++ b/backend/spec/requests/api/v1/tasks_spec.rb
@@ -43,11 +43,18 @@ RSpec.describe "Api::V1::Tasks", type: :request do
         attributes_for(:task, title: "task_update", user_id: user.id,
                               files: fixture_file_upload("file2.txt", "text/txt"))
       end
+      let(:params_blank) { attributes_for(:task, title: "", user_id: user.id) }
 
       it "タスクの情報更新に成功すること" do
         patch "/api/v1/tasks/#{task.id}", params: params.to_json, headers: headers
         expect(response).to have_http_status(:ok)
         expect(response.body).to include(params[:title])
+      end
+
+      it "タイトルが入力されていないとエラーメッセージが返ってくること" do
+        patch "/api/v1/tasks/#{task.id}", params: params_blank.to_json, headers: headers
+        expect(response).to have_http_status(:internal_server_error)
+        expect(json["messages"][0]).to eq "タイトルを入力してください"
       end
     end
 

--- a/backend/spec/requests/api/v1/tasks_spec.rb
+++ b/backend/spec/requests/api/v1/tasks_spec.rb
@@ -2,9 +2,10 @@ require "rails_helper"
 
 RSpec.describe "Api::V1::Tasks", type: :request do
   let(:team) { create(:team) }
-  let(:user) { create(:user, team:) }
+  let!(:user) { create(:user, team:) }
   let(:task) { create(:task, user:) }
   let(:headers) { { "Content-Type" => "application/json" } }
+  let(:json) { JSON.parse(response.body) }
 
   context "ユーザーがログインしている時" do
     before do
@@ -13,12 +14,19 @@ RSpec.describe "Api::V1::Tasks", type: :request do
 
     describe "POST /" do
       let(:params) { attributes_for(:task, user_id: user.id, files: fixture_file_upload("file.txt", "text/txt")) }
+      let(:params_blank) { attributes_for(:task, title: "", user_id: user.id) }
 
       it "タスクの新規作成に成功すること" do
         expect do
           post "/api/v1/tasks", params: params.to_json, headers:
         end.to change { user.tasks.count }.by(1)
         expect(response).to have_http_status(:created)
+      end
+
+      it "タイトルが入力されていないとエラーメッセージが返ってくること" do
+        post "/api/v1/tasks", params: params_blank.to_json, headers: headers
+        expect(response).to have_http_status(:internal_server_error)
+        expect(json["messages"][0]).to eq "タイトルを入力してください"
       end
     end
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,103 +18,106 @@ import "@fontsource/roboto/700.css";
 import PrivateRoute from "./components/PrivateRoute";
 import PublicRoute from "./components/PublicRoute";
 import CommonLayout from "./components/CommonLayout";
+import { SnackbarProvider } from "./providers/SnackbarProvider";
 
 const App: React.FC = () => {
   return (
     <BrowserRouter>
       <AuthProvider>
-        <CommonLayout>
-          <Routes>
-            <Route
-              path="/"
-              element={
-                <PublicRoute>
-                  <Home />
-                </PublicRoute>
-              }
-            />
-            <Route
-              path="/sign_up/teams/select"
-              element={
-                <PublicRoute>
-                  <TeamsSelect />
-                </PublicRoute>
-              }
-            />
-            <Route
-              path="/sign_up"
-              element={
-                <PublicRoute>
-                  <SignUp />
-                </PublicRoute>
-              }
-            />
-            <Route
-              path="/sign_in"
-              element={
-                <PublicRoute>
-                  <SignIn />
-                </PublicRoute>
-              }
-            />
-            <Route
-              path="/teams/:id"
-              element={
-                <PrivateRoute>
-                  <TeamsShow />
-                </PrivateRoute>
-              }
-            />
-            <Route
-              path="users/:id"
-              element={
-                <PrivateRoute>
-                  <UsersShow />
-                </PrivateRoute>
-              }
-            />
-            <Route
-              path="users/:id/edit"
-              element={
-                <PrivateRoute>
-                  <UsersEdit />
-                </PrivateRoute>
-              }
-            />
-            <Route
-              path="/tasks/new"
-              element={
-                <PrivateRoute>
-                  <TasksNew />
-                </PrivateRoute>
-              }
-            />
-            <Route
-              path="/tasks/:id"
-              element={
-                <PrivateRoute>
-                  <TasksShow />
-                </PrivateRoute>
-              }
-            />
-            <Route
-              path="/tasks/:id/edit"
-              element={
-                <PrivateRoute>
-                  <TasksEdit />
-                </PrivateRoute>
-              }
-            />
-            <Route
-              path="/tasks/:id/divisions/new"
-              element={
-                <PrivateRoute>
-                  <DivisionsNew />
-                </PrivateRoute>
-              }
-            />
-          </Routes>
-        </CommonLayout>
+        <SnackbarProvider>
+          <CommonLayout>
+            <Routes>
+              <Route
+                path="/"
+                element={
+                  <PublicRoute>
+                    <Home />
+                  </PublicRoute>
+                }
+              />
+              <Route
+                path="/sign_up/teams/select"
+                element={
+                  <PublicRoute>
+                    <TeamsSelect />
+                  </PublicRoute>
+                }
+              />
+              <Route
+                path="/sign_up"
+                element={
+                  <PublicRoute>
+                    <SignUp />
+                  </PublicRoute>
+                }
+              />
+              <Route
+                path="/sign_in"
+                element={
+                  <PublicRoute>
+                    <SignIn />
+                  </PublicRoute>
+                }
+              />
+              <Route
+                path="/teams/:id"
+                element={
+                  <PrivateRoute>
+                    <TeamsShow />
+                  </PrivateRoute>
+                }
+              />
+              <Route
+                path="users/:id"
+                element={
+                  <PrivateRoute>
+                    <UsersShow />
+                  </PrivateRoute>
+                }
+              />
+              <Route
+                path="users/:id/edit"
+                element={
+                  <PrivateRoute>
+                    <UsersEdit />
+                  </PrivateRoute>
+                }
+              />
+              <Route
+                path="/tasks/new"
+                element={
+                  <PrivateRoute>
+                    <TasksNew />
+                  </PrivateRoute>
+                }
+              />
+              <Route
+                path="/tasks/:id"
+                element={
+                  <PrivateRoute>
+                    <TasksShow />
+                  </PrivateRoute>
+                }
+              />
+              <Route
+                path="/tasks/:id/edit"
+                element={
+                  <PrivateRoute>
+                    <TasksEdit />
+                  </PrivateRoute>
+                }
+              />
+              <Route
+                path="/tasks/:id/divisions/new"
+                element={
+                  <PrivateRoute>
+                    <DivisionsNew />
+                  </PrivateRoute>
+                }
+              />
+            </Routes>
+          </CommonLayout>
+        </SnackbarProvider>
       </AuthProvider>
     </BrowserRouter>
   );

--- a/frontend/src/components/AlertSnackbar.tsx
+++ b/frontend/src/components/AlertSnackbar.tsx
@@ -1,0 +1,33 @@
+import { SyntheticEvent, useContext } from "react";
+import { Alert, Snackbar, Stack } from "@mui/material";
+import { SnackbarContext } from "../providers/SnackbarProvider";
+
+export const AlertSnackbar = () => {
+  const { snackbarState, setSnackbarState } = useContext(SnackbarContext);
+
+  const handleClose = (event?: SyntheticEvent | Event, reason?: string) => {
+    if (reason === "clickaway") {
+      return;
+    }
+    setSnackbarState({ ...snackbarState, open: false });
+  };
+
+  return (
+    <Stack sx={{ width: "100%" }} spacing={2}>
+      <Snackbar
+        anchorOrigin={{ vertical: "top", horizontal: "center" }}
+        open={snackbarState.open}
+        autoHideDuration={6000}
+        onClose={handleClose}
+      >
+        <Alert
+          onClose={handleClose}
+          severity={snackbarState.type}
+          sx={{ width: "100%" }}
+        >
+          {snackbarState.message}
+        </Alert>
+      </Snackbar>
+    </Stack>
+  );
+};

--- a/frontend/src/components/CommonLayout.tsx
+++ b/frontend/src/components/CommonLayout.tsx
@@ -3,6 +3,7 @@ import { Box, Container, Grid } from "@mui/material";
 import { FC } from "react";
 import { RouteProps } from "react-router-dom";
 import Header from "./Header";
+import { AlertSnackbar } from "./AlertSnackbar";
 
 const CommonLayout: FC<RouteProps> = ({ children }) => {
   const global = css`
@@ -13,11 +14,12 @@ const CommonLayout: FC<RouteProps> = ({ children }) => {
 
   return (
     <div>
+      <Global styles={global} />
       <header>
         <Header />
       </header>
       <main>
-        <Global styles={global} />
+        <AlertSnackbar />
         <Box m={2} pt={4}>
           <Container maxWidth="lg">
             <Grid container justifyContent="center">

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -12,10 +12,12 @@ import {
 import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { axiosInstance } from "../utils/axios";
 import { AuthContext } from "../providers/AuthProvider";
+import { SnackbarContext } from "../providers/SnackbarProvider";
 
 // eslint-disable-next-line react/display-name
 const Header: FC = memo(() => {
   const { isSignedIn, setIsSignedIn, currentUser } = useContext(AuthContext);
+  const { handleSetSnackbar } = useContext(SnackbarContext);
   const navigate = useNavigate();
 
   const onClickSignOut = () => {
@@ -37,12 +39,24 @@ const Header: FC = memo(() => {
           Cookies.remove("_access_token");
           Cookies.remove("_client");
           Cookies.remove("_uid");
-
           setIsSignedIn(false);
+          handleSetSnackbar({
+            open: true,
+            type: "success",
+            message: "ログアウトしました",
+          });
           navigate("/", { replace: true });
         }
       })
-      .catch((err) => console.log(err));
+      .catch((err) => {
+        console.log(err);
+        handleSetSnackbar({
+          open: true,
+          type: "error",
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+          message: `${err.response.data.errors[0]}`,
+        });
+      });
   };
 
   return (

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -83,6 +83,7 @@ const Header: FC = memo(() => {
                   component={Link}
                   to={`/users/${currentUser?.id}/edit`}
                   sx={{ my: 2, color: "white", display: "block" }}
+                  data-testid="current-user-name"
                 >
                   {currentUser?.name}
                 </Button>

--- a/frontend/src/mocks/mockAuth.ts
+++ b/frontend/src/mocks/mockAuth.ts
@@ -29,7 +29,13 @@ export const mockSignIn: ResponseResolver<MockedRequest, typeof restContext> = (
       })
     );
   }
-  return res(ctx.status(401));
+  return res(
+    ctx.status(401),
+    ctx.json({
+      success: false,
+      errors: ["ログイン用の認証情報が正しくありません。再度お試しください。"],
+    })
+  );
 };
 
 export const mockAuthSessions: ResponseResolver<

--- a/frontend/src/pages/DivisionsNew.tsx
+++ b/frontend/src/pages/DivisionsNew.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, FC, useEffect, useState } from "react";
+import { ChangeEvent, FC, useContext, useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import Cookies from "js-cookie";
 import { Button, Grid, MenuItem, TextField, Typography } from "@mui/material";
@@ -12,8 +12,10 @@ import {
 } from "../types";
 import { DeadlineTextField } from "../components/DeadlineTextField";
 import { PriorityTextField } from "../components/PriorityTextField";
+import { SnackbarContext } from "../providers/SnackbarProvider";
 
 const DivisionsNew: FC = () => {
+  const { handleSetSnackbar } = useContext(SnackbarContext);
   const params = useParams<{ id: string }>();
   const navigate = useNavigate();
 
@@ -64,10 +66,23 @@ const DivisionsNew: FC = () => {
         console.log(res);
 
         if (res.status === 200) {
+          handleSetSnackbar({
+            open: true,
+            type: "success",
+            message: "分担タスクを送信しました",
+          });
           navigate(`/users/${res.data.division.user_id}`, { replace: false });
         }
       })
-      .catch((err) => console.log(err));
+      .catch((err) => {
+        console.log(err);
+        handleSetSnackbar({
+          open: true,
+          type: "error",
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+          message: `${err.response.data.messages.join("。")}`,
+        });
+      });
   };
 
   const options: AxiosRequestConfig = {

--- a/frontend/src/pages/SignIn.tsx
+++ b/frontend/src/pages/SignIn.tsx
@@ -46,7 +46,7 @@ const SignIn: FC = () => {
           open: true,
           type: "error",
           // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-          message: `${err.response.data.errors[0]}`,
+          message: `${err.response.data.errors}`,
         });
       });
   };

--- a/frontend/src/pages/SignIn.tsx
+++ b/frontend/src/pages/SignIn.tsx
@@ -6,13 +6,15 @@ import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { axiosInstance } from "../utils/axios";
 import { AuthContext } from "../providers/AuthProvider";
 import { AuthResponse } from "../types";
+import { SnackbarContext } from "../providers/SnackbarProvider";
 
 const SignIn: FC = () => {
+  const { setIsSignedIn } = useContext(AuthContext);
+  const { handleSetSnackbar } = useContext(SnackbarContext);
+  const navigate = useNavigate();
+
   const [email, setEmail] = useState<string>("");
   const [password, setPassword] = useState<string>("");
-
-  const { setIsSignedIn } = useContext(AuthContext);
-  const navigate = useNavigate();
 
   const onClickSignIn = () => {
     const options: AxiosRequestConfig = {
@@ -29,12 +31,24 @@ const SignIn: FC = () => {
           Cookies.set("_access_token", res.headers["access-token"]);
           Cookies.set("_client", res.headers.client);
           Cookies.set("_uid", res.headers.uid);
-
           setIsSignedIn(true);
+          handleSetSnackbar({
+            open: true,
+            type: "success",
+            message: "ログインしました",
+          });
           navigate(`/teams/${res.data.data.team_id}`, { replace: false });
         }
       })
-      .catch((err) => console.log(err));
+      .catch((err) => {
+        console.log(err);
+        handleSetSnackbar({
+          open: true,
+          type: "error",
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+          message: `${err.response.data.errors[0]}`,
+        });
+      });
   };
 
   return (

--- a/frontend/src/pages/TasksEdit.tsx
+++ b/frontend/src/pages/TasksEdit.tsx
@@ -9,11 +9,13 @@ import { AuthContext } from "../providers/AuthProvider";
 import { useFetchTask } from "../hooks/useFetchTask";
 import { PriorityTextField } from "../components/PriorityTextField";
 import { DeadlineTextField } from "../components/DeadlineTextField";
+import { SnackbarContext } from "../providers/SnackbarProvider";
 
 const TasksEdit: FC = () => {
-  const params = useParams<{ id: string }>();
-  const navigate = useNavigate();
   const { currentUser } = useContext(AuthContext);
+  const { handleSetSnackbar } = useContext(SnackbarContext);
+  const navigate = useNavigate();
+  const params = useParams<{ id: string }>();
   const data = useFetchTask();
 
   const [task, setTask] = useState<editTask>({
@@ -51,10 +53,23 @@ const TasksEdit: FC = () => {
         console.log(res);
 
         if (res.status === 200) {
+          handleSetSnackbar({
+            open: true,
+            type: "success",
+            message: "タスクを更新しました",
+          });
           navigate(`/users/${currentUser?.id}`, { replace: false });
         }
       })
-      .catch((err) => console.log(err));
+      .catch((err) => {
+        console.log(err);
+        handleSetSnackbar({
+          open: true,
+          type: "error",
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+          message: `${err.response.data.messages.join("。")}`,
+        });
+      });
   };
 
   useEffect(() => {

--- a/frontend/src/pages/TasksNew.tsx
+++ b/frontend/src/pages/TasksNew.tsx
@@ -8,9 +8,11 @@ import { TasksResponse, newTask } from "../types";
 import { AuthContext } from "../providers/AuthProvider";
 import { PriorityTextField } from "../components/PriorityTextField";
 import { DeadlineTextField } from "../components/DeadlineTextField";
+import { SnackbarContext } from "../providers/SnackbarProvider";
 
 const TasksNew: FC = () => {
   const { currentUser } = useContext(AuthContext);
+  const { handleSetSnackbar } = useContext(SnackbarContext);
   const navigate = useNavigate();
 
   const [task, setTask] = useState<newTask>({
@@ -54,10 +56,23 @@ const TasksNew: FC = () => {
         console.log(res);
 
         if (res.status === 201) {
+          handleSetSnackbar({
+            open: true,
+            type: "success",
+            message: "タスクを作成しました",
+          });
           navigate(`/users/${currentUser?.id}`, { replace: false });
         }
       })
-      .catch((err) => console.log(err));
+      .catch((err) => {
+        console.log(err);
+        handleSetSnackbar({
+          open: true,
+          type: "error",
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+          message: `${err.response.data.messages.join("。")}`,
+        });
+      });
   };
 
   return (

--- a/frontend/src/pages/UsersEdit.tsx
+++ b/frontend/src/pages/UsersEdit.tsx
@@ -7,10 +7,12 @@ import { axiosInstance } from "../utils/axios";
 import { useFetchUser } from "../hooks/useFetchUser";
 import { AuthContext } from "../providers/AuthProvider";
 import { User, UsersResponse } from "../types";
+import { SnackbarContext } from "../providers/SnackbarProvider";
 
 const UsersEdit: FC = () => {
-  const navigate = useNavigate();
   const { currentUser, setCurrentUser } = useContext(AuthContext);
+  const { handleSetSnackbar } = useContext(SnackbarContext);
+  const navigate = useNavigate();
   const { user: userData } = useFetchUser();
 
   const [user, setUser] = useState<User>({
@@ -54,10 +56,23 @@ const UsersEdit: FC = () => {
 
         if (res.status === 200) {
           setCurrentUser(user);
+          handleSetSnackbar({
+            open: true,
+            type: "success",
+            message: "ユーザー情報を更新しました",
+          });
           navigate(`/users/${currentUser?.id}`, { replace: false });
         }
       })
-      .catch((err) => console.log(err));
+      .catch((err) => {
+        console.log(err);
+        handleSetSnackbar({
+          open: true,
+          type: "error",
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+          message: `${err.response.data.errors.full_messages.join("。")}`,
+        });
+      });
   };
 
   useEffect(() => {

--- a/frontend/src/providers/SnackbarProvider.tsx
+++ b/frontend/src/providers/SnackbarProvider.tsx
@@ -22,6 +22,7 @@ type State = {
 type SnackbarState = {
   snackbarState: State;
   setSnackbarState: Dispatch<SetStateAction<State>>;
+  handleSetSnackbar: ({ open, type, message }: State) => void;
 };
 
 export const SnackbarContext = createContext<SnackbarState>(
@@ -35,9 +36,13 @@ export const SnackbarProvider: FC<Props> = ({ children }) => {
     message: "",
   });
 
+  const handleSetSnackbar = ({ open, type, message }: State) => {
+    setSnackbarState({ open, type, message });
+  };
+
   const SnackbarStateValue = useMemo(
-    () => ({ snackbarState, setSnackbarState }),
-    [snackbarState, setSnackbarState]
+    () => ({ snackbarState, setSnackbarState, handleSetSnackbar }),
+    [snackbarState, setSnackbarState, handleSetSnackbar]
   );
 
   return (

--- a/frontend/src/providers/SnackbarProvider.tsx
+++ b/frontend/src/providers/SnackbarProvider.tsx
@@ -1,0 +1,48 @@
+import {
+  createContext,
+  Dispatch,
+  FC,
+  ReactNode,
+  SetStateAction,
+  useMemo,
+  useState,
+} from "react";
+import { AlertColor } from "@mui/material";
+
+type Props = {
+  children: ReactNode;
+};
+
+type State = {
+  open: boolean;
+  type: AlertColor | undefined;
+  message: string;
+};
+
+type SnackbarState = {
+  snackbarState: State;
+  setSnackbarState: Dispatch<SetStateAction<State>>;
+};
+
+export const SnackbarContext = createContext<SnackbarState>(
+  {} as SnackbarState
+);
+
+export const SnackbarProvider: FC<Props> = ({ children }) => {
+  const [snackbarState, setSnackbarState] = useState<State>({
+    open: false,
+    type: "success",
+    message: "",
+  });
+
+  const SnackbarStateValue = useMemo(
+    () => ({ snackbarState, setSnackbarState }),
+    [snackbarState, setSnackbarState]
+  );
+
+  return (
+    <SnackbarContext.Provider value={SnackbarStateValue}>
+      {children}
+    </SnackbarContext.Provider>
+  );
+};

--- a/frontend/src/tests/DivisionsNew.test.tsx
+++ b/frontend/src/tests/DivisionsNew.test.tsx
@@ -1,14 +1,16 @@
+/* eslint-disable @typescript-eslint/await-thenable */
 /* eslint-disable testing-library/no-unnecessary-act */
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { rest } from "msw";
 import { act } from "react-dom/test-utils";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
-import Header from "../components/Header";
 import { server } from "../mocks/server";
 import { AuthProvider } from "../providers/AuthProvider";
 import DivisionsNew from "../pages/DivisionsNew";
 import UsersShow from "../pages/UsersShow";
+import { SnackbarProvider } from "../providers/SnackbarProvider";
+import CommonLayout from "../components/CommonLayout";
 
 describe("DivisionsNew", () => {
   test("分担作成ページ", async () => {
@@ -37,11 +39,17 @@ describe("DivisionsNew", () => {
     render(
       <MemoryRouter initialEntries={["/tasks/1/divisions/new"]}>
         <AuthProvider>
-          <Header />
-          <Routes>
-            <Route path="/users/:id" element={<UsersShow />} />
-            <Route path="/tasks/:id/divisions/new" element={<DivisionsNew />} />
-          </Routes>
+          <SnackbarProvider>
+            <CommonLayout>
+              <Routes>
+                <Route path="/users/:id" element={<UsersShow />} />
+                <Route
+                  path="/tasks/:id/divisions/new"
+                  element={<DivisionsNew />}
+                />
+              </Routes>
+            </CommonLayout>
+          </SnackbarProvider>
         </AuthProvider>
       </MemoryRouter>
     );
@@ -59,7 +67,7 @@ describe("DivisionsNew", () => {
     // チームメンバーが表示される
     expect(await screen.findByText("USER_2")).toBeInTheDocument();
 
-    act(() => {
+    await act(() => {
       userEvent.click(screen.getByText("USER_2"));
       userEvent.type(screen.getByLabelText("送信コメント"), "Thank you");
       userEvent.click(screen.getByTestId("send-button"));
@@ -67,5 +75,8 @@ describe("DivisionsNew", () => {
 
     // UsersShowページに遷移する
     expect(await screen.findByTestId("users-show-h4")).toBeInTheDocument();
+    expect(
+      await screen.findByText("分担タスクを送信しました")
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/tests/Header.test.tsx
+++ b/frontend/src/tests/Header.test.tsx
@@ -1,11 +1,7 @@
 import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import renderer from "react-test-renderer";
-import { act } from "react-dom/test-utils";
 import { BrowserRouter } from "react-router-dom";
 import Header from "../components/Header";
-import SignIn from "../pages/SignIn";
-import { AuthProvider } from "../providers/AuthProvider";
 
 describe("Header", () => {
   test("スナップショット", () => {
@@ -22,29 +18,5 @@ describe("Header", () => {
   test("サインインボタンの表示", () => {
     render(<Header />, { wrapper: BrowserRouter });
     expect(screen.getByText("サインイン")).toBeInTheDocument();
-  });
-
-  test("ログインユーザー名の表示", async () => {
-    render(
-      <BrowserRouter>
-        <AuthProvider>
-          <Header />
-          <SignIn />
-        </AuthProvider>
-      </BrowserRouter>
-    );
-
-    const emailInput = screen.getByLabelText("メールアドレス");
-    const passwordInput = screen.getByLabelText("パスワード");
-    const signInButton = screen.getByTestId("sign-in-button");
-
-    // eslint-disable-next-line testing-library/no-unnecessary-act
-    act(() => {
-      userEvent.type(emailInput, "test@example.com");
-      userEvent.type(passwordInput, "testtest");
-      userEvent.click(signInButton);
-    });
-
-    expect(await screen.findByText("USER_1")).toBeInTheDocument();
   });
 });

--- a/frontend/src/tests/SignIn.test.tsx
+++ b/frontend/src/tests/SignIn.test.tsx
@@ -39,6 +39,17 @@ describe("SignIn", () => {
       </MemoryRouter>
     );
 
+    // email, passwordを入力しない時
+    act(() => {
+      userEvent.click(screen.getByTestId("sign-in-button"));
+    });
+    expect(
+      await screen.findByText(
+        "ログイン用の認証情報が正しくありません。再度お試しください。"
+      )
+    ).toBeInTheDocument();
+
+    // email, passwordを入力した時
     await act(() => {
       userEvent.type(
         screen.getByLabelText("メールアドレス"),
@@ -50,7 +61,6 @@ describe("SignIn", () => {
 
     // Headerにログインユーザー名が表示される
     expect(await screen.findByTestId("current-user-name")).toBeInTheDocument();
-    // "ログインしました"メッセージが表示される
     expect(await screen.findByText("ログインしました")).toBeInTheDocument();
   });
 });

--- a/frontend/src/tests/SignIn.test.tsx
+++ b/frontend/src/tests/SignIn.test.tsx
@@ -1,6 +1,15 @@
+/* eslint-disable @typescript-eslint/await-thenable */
+/* eslint-disable testing-library/no-unnecessary-act */
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import renderer from "react-test-renderer";
-import { BrowserRouter } from "react-router-dom";
+import { act } from "react-dom/test-utils";
+import { BrowserRouter, MemoryRouter, Route, Routes } from "react-router-dom";
 import SignIn from "../pages/SignIn";
+import { AuthProvider } from "../providers/AuthProvider";
+import TeamsShow from "../pages/TeamsShow";
+import { SnackbarProvider } from "../providers/SnackbarProvider";
+import CommonLayout from "../components/CommonLayout";
 
 describe("SignIn", () => {
   test("スナップショット", () => {
@@ -12,5 +21,36 @@ describe("SignIn", () => {
       )
       .toJSON();
     expect(tree).toMatchSnapshot();
+  });
+
+  test("サインイン後の表示", async () => {
+    render(
+      <MemoryRouter initialEntries={["/sign_in"]}>
+        <AuthProvider>
+          <SnackbarProvider>
+            <CommonLayout>
+              <Routes>
+                <Route path="/sign_in" element={<SignIn />} />
+                <Route path="/teams/:id" element={<TeamsShow />} />
+              </Routes>
+            </CommonLayout>
+          </SnackbarProvider>
+        </AuthProvider>
+      </MemoryRouter>
+    );
+
+    await act(() => {
+      userEvent.type(
+        screen.getByLabelText("メールアドレス"),
+        "test@example.com"
+      );
+      userEvent.type(screen.getByLabelText("パスワード"), "testtest");
+      userEvent.click(screen.getByTestId("sign-in-button"));
+    });
+
+    // Headerにログインユーザー名が表示される
+    expect(await screen.findByTestId("current-user-name")).toBeInTheDocument();
+    // "ログインしました"メッセージが表示される
+    expect(await screen.findByText("ログインしました")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
### 目的
ログイン/ログアウトなどの処理結果をスナックバーで通知させる。

### 変更内容
- エラー時のレスポンスメッセージを修正
- `AlertSnackbar`コンポーネント、`SnackbarProvider`の作成
- ユーザー作成/編集、ログイン/ログアウト、タスク作成/更新、分担作成時にメッセージ表示するようロジック追加
- テスト作成