### PR TITLE
feat: アバターを設定出来るようにする #131

### DIFF
--- a/backend/.rubocop.yml
+++ b/backend/.rubocop.yml
@@ -67,3 +67,6 @@ Metrics/MethodLength:
 
 RSpec/ExampleLength:
   Enabled: false
+
+Metrics/AbcSize:
+  Max: 25

--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -31,6 +31,7 @@ gem "devise-i18n"
 gem "devise_token_auth"
 gem "dotenv-rails"
 gem "faker"
+gem "image_processing", "~> 1.2"
 gem "net-imap", require: false
 gem "net-pop", require: false
 gem "net-smtp", require: false

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -113,6 +113,9 @@ GEM
       activesupport (>= 5.0)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
+    image_processing (1.12.2)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     jmespath (1.6.1)
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -124,6 +127,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
     method_source (1.0.0)
+    mini_magick (4.11.0)
     mini_mime (1.1.2)
     minitest (5.15.0)
     msgpack (1.5.1)
@@ -239,6 +243,8 @@ GEM
     rubocop-rspec (2.11.1)
       rubocop (~> 1.19)
     ruby-progressbar (1.11.0)
+    ruby-vips (2.1.4)
+      ffi (~> 1.12)
     sd_notify (0.1.1)
     spring (4.0.0)
     sprockets (4.0.3)
@@ -274,6 +280,7 @@ DEPENDENCIES
   dotenv-rails
   factory_bot
   faker
+  image_processing (~> 1.2)
   listen (~> 3.3)
   mysql2 (~> 0.5)
   net-imap

--- a/backend/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/backend/app/controllers/api/v1/auth/registrations_controller.rb
@@ -1,6 +1,26 @@
 class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsController
   before_action :ensure_normal_user, only: [:update, :destroy]
 
+  def update
+    if @resource
+      if params[:avatar]
+        blob = ActiveStorage::Blob.create_after_upload!(
+          io: StringIO.new("#{decode(params[:avatar][:data])}\n"),
+          filename: params[:avatar][:filename]
+        )
+        @resource.avatar.attach(blob)
+      end
+      if @resource.send(resource_update_method, account_update_params)
+        yield @resource if block_given?
+        render_update_success
+      else
+        render_update_error
+      end
+    else
+      render_update_error_user_not_found
+    end
+  end
+
   private
 
   def sign_up_params
@@ -15,5 +35,9 @@ class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsCon
     if @resource.email == "guest@example.com"
       render json: { messages: "ゲストユーザーの更新・削除は出来ません" }, status: :internal_server_error
     end
+  end
+
+  def decode(str)
+    Base64.decode64(str.split(",").last)
   end
 end

--- a/backend/app/controllers/api/v1/users_controller.rb
+++ b/backend/app/controllers/api/v1/users_controller.rb
@@ -5,7 +5,16 @@ class Api::V1::UsersController < ApplicationController
   def show
     unfinished_tasks = @user.tasks.unfinished
     finished_tasks = @user.tasks.finished
-    render json: { user: @user, unfinished_tasks:, finished_tasks: }, status: :ok
+
+    avatar_url = if @user.avatar.attached?
+                   url_for(@user.avatar)
+                 else
+                   ""
+                 end
+
+    render json: {
+      user: @user, unfinished_tasks:, finished_tasks:, avatar: avatar_url
+    }, status: :ok
   end
 
   private

--- a/backend/config/application.rb
+++ b/backend/config/application.rb
@@ -48,5 +48,7 @@ module Divwork
                        helper_specs: false,
                        routing_specs: false
     end
+
+    config.active_storage.routes_prefix = "/api/v1"
   end
 end

--- a/backend/spec/requests/api/v1/auth/registrations_spec.rb
+++ b/backend/spec/requests/api/v1/auth/registrations_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "Api::V1::Auth::Registrations", type: :request do
   end
 
   describe "PATCH /api/v1/auth" do
-    let(:params) { { name: "new_name", avatar: fixture_file_upload("blank.jpg", "image/jpg") } }
+    let(:params) { { name: "new_name", avatar: { data: "abc", filename: "blank.jpeg" } } }
 
     before do
       patch "/api/v1/auth", params:, headers:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "@emotion/react": "^11.9.3",
     "@emotion/styled": "^11.9.3",
     "@fontsource/roboto": "^4.5.7",
+    "@mui/icons-material": "^5.10.3",
     "@mui/material": "^5.9.0",
     "@mui/x-date-pickers": "^5.0.0-beta.1",
     "@testing-library/react": "^13.0.0",

--- a/frontend/src/hooks/useFetchUser.ts
+++ b/frontend/src/hooks/useFetchUser.ts
@@ -6,10 +6,12 @@ import { Task, User, UsersResponse } from "../types";
 import { axiosInstance } from "../utils/axios";
 
 export const useFetchUser = () => {
+  const params = useParams<{ id: string }>();
+
   const [user, setUser] = useState<User>();
   const [unfinishedTasks, setUnfinishedTasks] = useState<Task[]>([]);
   const [finishedTasks, setFinishedTasks] = useState<Task[]>([]);
-  const params = useParams<{ id: string }>();
+  const [avatar, setAvatar] = useState<string>("");
 
   const options: AxiosRequestConfig = {
     url: `/users/${params.id}`,
@@ -28,11 +30,12 @@ export const useFetchUser = () => {
         setUser(res?.data.user);
         setUnfinishedTasks(res?.data.unfinished_tasks);
         setFinishedTasks(res?.data.finished_tasks);
+        setAvatar(res?.data.avatar);
       })
       .catch((err) => {
         console.log(err);
       });
   }, []);
 
-  return { user, unfinishedTasks, finishedTasks };
+  return { user, unfinishedTasks, finishedTasks, avatar };
 };

--- a/frontend/src/pages/UsersEdit.tsx
+++ b/frontend/src/pages/UsersEdit.tsx
@@ -8,7 +8,8 @@ import {
 } from "react";
 import { useNavigate } from "react-router-dom";
 import Cookies from "js-cookie";
-import { Button, Grid, TextField, Typography } from "@mui/material";
+import { Button, Grid, IconButton, TextField, Typography } from "@mui/material";
+import PhotoCamera from "@mui/icons-material/PhotoCamera";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { axiosInstance } from "../utils/axios";
 import { useFetchUser } from "../hooks/useFetchUser";
@@ -120,6 +121,53 @@ const UsersEdit: FC = () => {
           </Typography>
         </Grid>
         <Grid item>
+          <Grid container direction="column" spacing={1} alignContent="center">
+            <Grid item>
+              <Grid
+                container
+                direction="row"
+                justifyContent="space-between"
+                alignItems="center"
+              >
+                <Grid item>
+                  <Typography variant="subtitle1" component="div">
+                    アイコン画像
+                  </Typography>
+                </Grid>
+                <Grid item>
+                  <IconButton
+                    color="primary"
+                    aria-label="upload picture"
+                    component="label"
+                  >
+                    <input
+                      hidden
+                      accept="image/*"
+                      type="file"
+                      onChange={handleImageSelect}
+                    />
+                    <PhotoCamera />
+                  </IconButton>
+                </Grid>
+              </Grid>
+            </Grid>
+            <Grid item>
+              {avatar ? (
+                <img src={avatar} alt="avatar" width={300} height="auto" />
+              ) : (
+                <Typography variant="body1" component="div">
+                  設定されていません
+                </Typography>
+              )}
+            </Grid>
+            {image ? (
+              <Typography variant="body1" component="div">
+                {image.filename}
+              </Typography>
+            ) : null}
+          </Grid>
+        </Grid>
+        <Grid item>
           <Typography>{user?.team_id}</Typography>
         </Grid>
         <Grid item>
@@ -149,27 +197,6 @@ const UsersEdit: FC = () => {
         </Grid>
         <Grid item>
           <Button variant="outlined">パスワード変更</Button>
-        </Grid>
-        {image ? (
-          <Grid item>
-            <p>{image.filename}</p>
-          </Grid>
-        ) : null}
-        {avatar ? (
-          <Grid item>
-            <img src={avatar} alt="avatar" />
-          </Grid>
-        ) : null}
-        <Grid item>
-          <Button variant="contained" component="label">
-            Upload
-            <input
-              hidden
-              accept="image/*"
-              type="file"
-              onChange={handleImageSelect}
-            />
-          </Button>
         </Grid>
       </Grid>
     </div>

--- a/frontend/src/pages/UsersEdit.tsx
+++ b/frontend/src/pages/UsersEdit.tsx
@@ -20,7 +20,7 @@ const UsersEdit: FC = () => {
   const { currentUser, setCurrentUser } = useContext(AuthContext);
   const { handleSetSnackbar } = useContext(SnackbarContext);
   const navigate = useNavigate();
-  const { user: userData } = useFetchUser();
+  const { user: userData, avatar } = useFetchUser();
 
   const [user, setUser] = useState<User>({
     team_id: 0,
@@ -35,7 +35,6 @@ const UsersEdit: FC = () => {
     created_at: new Date(),
     updated_at: new Date(),
     unfinished_tasks_count: [0],
-    avatar: "",
   });
 
   const [image, setImage] = useState({
@@ -156,9 +155,9 @@ const UsersEdit: FC = () => {
             <p>{image.filename}</p>
           </Grid>
         ) : null}
-        {user.avatar ? (
+        {avatar ? (
           <Grid item>
-            <img src={user.avatar} alt="avatar" />
+            <img src={avatar} alt="avatar" />
           </Grid>
         ) : null}
         <Grid item>

--- a/frontend/src/pages/UsersEdit.tsx
+++ b/frontend/src/pages/UsersEdit.tsx
@@ -1,4 +1,11 @@
-import { ChangeEvent, FC, useContext, useEffect, useState } from "react";
+import {
+  ChangeEvent,
+  FC,
+  FormEvent,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
 import { useNavigate } from "react-router-dom";
 import Cookies from "js-cookie";
 import { Button, Grid, TextField, Typography } from "@mui/material";
@@ -28,6 +35,12 @@ const UsersEdit: FC = () => {
     created_at: new Date(),
     updated_at: new Date(),
     unfinished_tasks_count: [0],
+    avatar: "",
+  });
+
+  const [image, setImage] = useState({
+    data: "",
+    filename: "",
   });
 
   const handleInputChange = (
@@ -47,7 +60,11 @@ const UsersEdit: FC = () => {
         client: Cookies.get("_client") || "",
         uid: Cookies.get("_uid") || "",
       },
-      data: user,
+      data: {
+        name: user.name,
+        email: user.email,
+        avatar: image,
+      },
     };
 
     axiosInstance(updateOptions)
@@ -70,9 +87,23 @@ const UsersEdit: FC = () => {
           open: true,
           type: "error",
           // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-          message: `${err.response.data.errors.full_messages.join("。")}`,
+          message: `${err.response.data.errors}`,
         });
       });
+  };
+
+  const handleImageSelect = (event: FormEvent) => {
+    const reader = new FileReader();
+    const { files } = event.target as HTMLInputElement;
+    if (files) {
+      reader.onload = () => {
+        setImage({
+          data: reader.result as string,
+          filename: files[0] ? files[0].name : "unknownfile",
+        });
+      };
+      reader.readAsDataURL(files[0]);
+    }
   };
 
   useEffect(() => {
@@ -119,6 +150,27 @@ const UsersEdit: FC = () => {
         </Grid>
         <Grid item>
           <Button variant="outlined">パスワード変更</Button>
+        </Grid>
+        {image ? (
+          <Grid item>
+            <p>{image.filename}</p>
+          </Grid>
+        ) : null}
+        {user.avatar ? (
+          <Grid item>
+            <img src={user.avatar} alt="avatar" />
+          </Grid>
+        ) : null}
+        <Grid item>
+          <Button variant="contained" component="label">
+            Upload
+            <input
+              hidden
+              accept="image/*"
+              type="file"
+              onChange={handleImageSelect}
+            />
+          </Button>
         </Grid>
       </Grid>
     </div>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -18,6 +18,7 @@ export type User = {
   created_at: Date;
   updated_at: Date;
   unfinished_tasks_count: number[];
+  avatar: string;
 };
 
 export type Task = {
@@ -40,6 +41,25 @@ export type Division = {
   created_at: Date;
   updated_at: Date;
   comment: string;
+};
+
+export type editUser = {
+  id: number;
+  provider: string;
+  uid: string;
+  allow_password_change: boolean;
+  name: string;
+  nickname: string;
+  image: string;
+  email: string;
+  team_id: number;
+  created_at: Date;
+  updated_at: Date;
+  unfinished_tasks_count: number[];
+  avatar: {
+    data: string;
+    filename: string;
+  };
 };
 
 export type newTask = {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -18,7 +18,6 @@ export type User = {
   created_at: Date;
   updated_at: Date;
   unfinished_tasks_count: number[];
-  avatar: string;
 };
 
 export type Task = {
@@ -107,6 +106,7 @@ export type UsersResponse = {
   user: User;
   unfinished_tasks: Task[];
   finished_tasks: Task[];
+  avatar: string;
 };
 
 export type TasksResponse = {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1865,6 +1865,13 @@
     prop-types "^15.8.1"
     react-is "^18.2.0"
 
+"@mui/icons-material@^5.10.3":
+  version "5.10.3"
+  resolved "https://registry.yarnpkg.com/@mui/icons-material/-/icons-material-5.10.3.tgz#33bd1d973c4727ab55d02928fc8973b7f16fff55"
+  integrity sha512-o0kbUlsWCBtCE0wP33cGKbyryCh7kpm2EECYMPDmWrLhbA+HUODXIdhiTFS26szp2xXo9HY1lEx0ufeJ+tddYw==
+  dependencies:
+    "@babel/runtime" "^7.18.9"
+
 "@mui/material@^5.9.0":
   version "5.9.1"
   resolved "https://registry.yarnpkg.com/@mui/material/-/material-5.9.1.tgz#92990e6d4035792430dcf548b91db6f335aebdd3"


### PR DESCRIPTION
### 変更内容
**backend**
- `registrations_controller`にアバター設定ロジックを追加
- `users#show`のレスポンスに`avatar`を追加

**frontend**
- `UsersEdit.tsx`に画像選択フォームと画像表示を追加
- `UsersEdit.tsx`に画像選択、画像投稿ロジックを追加