### PR TITLE
feat: チーム一覧ページにアバターを表示する #133

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -46,6 +46,7 @@ group :development, :test do
 end
 
 group :development do
+  gem "bullet"
   gem "listen", "~> 3.3"
   gem "pry-rails"
   gem "rubocop", "~> 1.29", require: false

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -81,6 +81,9 @@ GEM
     bootsnap (1.11.1)
       msgpack (~> 1.2)
     builder (3.2.4)
+    bullet (7.0.3)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     byebug (11.1.3)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
@@ -260,6 +263,7 @@ GEM
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.1.0)
+    uniform_notifier (1.16.0)
     warden (1.2.9)
       rack (>= 2.0.9)
     websocket-driver (0.7.5)
@@ -273,6 +277,7 @@ PLATFORMS
 DEPENDENCIES
   aws-sdk-s3
   bootsnap (>= 1.4.4)
+  bullet
   byebug
   devise
   devise-i18n

--- a/backend/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/backend/app/controllers/api/v1/auth/registrations_controller.rb
@@ -3,7 +3,7 @@ class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsCon
 
   def update
     if @resource
-      if params[:avatar]
+      if params[:avatar][:data].present?
         blob = ActiveStorage::Blob.create_after_upload!(
           io: StringIO.new("#{decode(params[:avatar][:data])}\n"),
           filename: params[:avatar][:filename]

--- a/backend/app/controllers/api/v1/teams_controller.rb
+++ b/backend/app/controllers/api/v1/teams_controller.rb
@@ -19,8 +19,12 @@ class Api::V1::TeamsController < ApplicationController
 
   def show
     users = @team.users
-    render json: { team: @team, users: users.as_json(methods: :unfinished_tasks_count) },
-           status: :ok
+    users = users.map do |user|
+      user.as_json(methods: :unfinished_tasks_count)
+          .merge(avatar: avatar_url(user))
+    end
+
+    render json: { team: @team, users: }, status: :ok
   end
 
   def update

--- a/backend/app/controllers/api/v1/users_controller.rb
+++ b/backend/app/controllers/api/v1/users_controller.rb
@@ -5,10 +5,9 @@ class Api::V1::UsersController < ApplicationController
   def show
     unfinished_tasks = @user.tasks.unfinished
     finished_tasks = @user.tasks.finished
+    @user = @user.as_json.merge(avatar: avatar_url(@user))
 
-    render json: {
-      user: @user, unfinished_tasks:, finished_tasks:, avatar: avatar_url(@user)
-    }, status: :ok
+    render json: { user: @user, unfinished_tasks:, finished_tasks: }, status: :ok
   end
 
   private

--- a/backend/app/controllers/api/v1/users_controller.rb
+++ b/backend/app/controllers/api/v1/users_controller.rb
@@ -6,14 +6,8 @@ class Api::V1::UsersController < ApplicationController
     unfinished_tasks = @user.tasks.unfinished
     finished_tasks = @user.tasks.finished
 
-    avatar_url = if @user.avatar.attached?
-                   url_for(@user.avatar)
-                 else
-                   ""
-                 end
-
     render json: {
-      user: @user, unfinished_tasks:, finished_tasks:, avatar: avatar_url
+      user: @user, unfinished_tasks:, finished_tasks:, avatar: avatar_url(@user)
     }, status: :ok
   end
 

--- a/backend/app/controllers/application_controller.rb
+++ b/backend/app/controllers/application_controller.rb
@@ -4,4 +4,12 @@ class ApplicationController < ActionController::API
   def error_messages(obj)
     obj.errors.full_messages
   end
+
+  def avatar_url(obj)
+    if obj.avatar.attached?
+      url_for(obj.avatar)
+    else
+      ""
+    end
+  end
 end

--- a/backend/spec/requests/api/v1/teams_spec.rb
+++ b/backend/spec/requests/api/v1/teams_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Api::V1::Teams", type: :request do
     it "チームの情報取得に成功すること" do
       get "/api/v1/teams/select"
       expect(response).to have_http_status(:ok)
-      expect(json["teams"][-1]).to include("id" => team.id)
+      expect(json["teams"][-1]["id"]).to eq team.id
     end
   end
 
@@ -31,6 +31,7 @@ RSpec.describe "Api::V1::Teams", type: :request do
 
   context "チームのユーザーがログインしている時" do
     let(:user) { create(:user, team:) }
+    let!(:task) { create(:task, user:, priority: 0) }
     let(:headers) { user.create_new_auth_token }
 
     describe "GET /:id" do
@@ -43,9 +44,16 @@ RSpec.describe "Api::V1::Teams", type: :request do
         expect(json["team"]["id"]).to eq team.id
       end
 
-      it "チームに所属するユーザーの情報取得に成功すること" do
-        get "/api/v1/teams/#{team.id}", headers: headers
-        expect(json["users"][0]).to include("id" => user.id)
+      it "チームに所属するユーザーの情報を取得出来ること" do
+        expect(json["users"][0]["id"]).to eq user.id
+      end
+
+      it "ユーザーの未完了タスク数を取得出来ること" do
+        expect(json["users"][0]["unfinished_tasks_count"]).to eq [1, 0, 0]
+      end
+
+      it "ユーザーのアバター情報が含まれること" do
+        expect(json["users"][0]["avatar"]).to eq ""
       end
     end
 

--- a/backend/spec/requests/api/v1/users_spec.rb
+++ b/backend/spec/requests/api/v1/users_spec.rb
@@ -18,16 +18,16 @@ RSpec.describe "Api::V1::Users", type: :request do
       expect(json["user"]["id"]).to eq user.id
     end
 
+    it "ユーザーのアバター情報を取得出来ること" do
+      expect(json["user"]["avatar"]).to eq ""
+    end
+
     it "ユーザーの未了タスクの情報取得に成功すること" do
       expect(json["unfinished_tasks"][0]["id"]).to eq unfinished_task.id
     end
 
     it "ユーザーの完了済みタスクの情報取得に成功すること" do
       expect(json["finished_tasks"][0]["id"]).to eq finished_task.id
-    end
-
-    it "ユーザーのアバター情報を取得出来ること" do
-      expect(json["avatar"]).to eq ""
     end
   end
 end

--- a/backend/spec/requests/api/v1/users_spec.rb
+++ b/backend/spec/requests/api/v1/users_spec.rb
@@ -25,5 +25,9 @@ RSpec.describe "Api::V1::Users", type: :request do
     it "ユーザーの完了済みタスクの情報取得に成功すること" do
       expect(json["finished_tasks"][0]["id"]).to eq finished_task.id
     end
+
+    it "ユーザーのアバター情報を取得出来ること" do
+      expect(json["avatar"]).to eq ""
+    end
   end
 end

--- a/frontend/src/components/CommonLayout.tsx
+++ b/frontend/src/components/CommonLayout.tsx
@@ -20,7 +20,7 @@ const CommonLayout: FC<RouteProps> = ({ children }) => {
       </header>
       <main>
         <AlertSnackbar />
-        <Box m={2} pt={4}>
+        <Box m={2} py={4}>
           <Container maxWidth="lg">
             <Grid container justifyContent="center">
               <Grid item>{children}</Grid>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -82,7 +82,7 @@ const Header: FC = memo(() => {
                 <Button
                   component={Link}
                   to={`/users/${currentUser?.id}/edit`}
-                  sx={{ my: 2, color: "white", display: "block" }}
+                  sx={{ my: 2, color: "white", display: "flex" }}
                   data-testid="current-user-name"
                 >
                   {currentUser?.name}
@@ -90,7 +90,7 @@ const Header: FC = memo(() => {
                 <Button
                   type="submit"
                   onClick={onClickSignOut}
-                  sx={{ my: 2, color: "white", display: "block" }}
+                  sx={{ my: 2, color: "white", display: "flex" }}
                 >
                   ログアウト
                 </Button>
@@ -100,14 +100,14 @@ const Header: FC = memo(() => {
                 <Button
                   component={Link}
                   to="/sign_up/teams/select"
-                  sx={{ my: 2, color: "white", display: "block" }}
+                  sx={{ my: 2, color: "white", display: "flex" }}
                 >
                   ユーザー登録
                 </Button>
                 <Button
                   component={Link}
                   to="/sign_in"
-                  sx={{ my: 2, color: "white", display: "block" }}
+                  sx={{ my: 2, color: "white", display: "flex" }}
                 >
                   ログイン
                 </Button>

--- a/frontend/src/components/TasksBar.tsx
+++ b/frontend/src/components/TasksBar.tsx
@@ -20,7 +20,7 @@ export const TasksBar = (props: Props) => {
 
   return (
     <BarChart
-      width={500}
+      width={600}
       height={70}
       barSize={16}
       layout="vertical"

--- a/frontend/src/hooks/useFetchUser.ts
+++ b/frontend/src/hooks/useFetchUser.ts
@@ -11,7 +11,6 @@ export const useFetchUser = () => {
   const [user, setUser] = useState<User>();
   const [unfinishedTasks, setUnfinishedTasks] = useState<Task[]>([]);
   const [finishedTasks, setFinishedTasks] = useState<Task[]>([]);
-  const [avatar, setAvatar] = useState<string>("");
 
   const options: AxiosRequestConfig = {
     url: `/users/${params.id}`,
@@ -30,12 +29,11 @@ export const useFetchUser = () => {
         setUser(res?.data.user);
         setUnfinishedTasks(res?.data.unfinished_tasks);
         setFinishedTasks(res?.data.finished_tasks);
-        setAvatar(res?.data.avatar);
       })
       .catch((err) => {
         console.log(err);
       });
   }, []);
 
-  return { user, unfinishedTasks, finishedTasks, avatar };
+  return { user, unfinishedTasks, finishedTasks };
 };

--- a/frontend/src/pages/TeamsShow.tsx
+++ b/frontend/src/pages/TeamsShow.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, FC } from "react";
 import { useParams, Link } from "react-router-dom";
 import Cookies from "js-cookie";
-import { Button, Divider, Grid, Typography } from "@mui/material";
+import { Avatar, Button, Divider, Grid, Typography } from "@mui/material";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { axiosInstance } from "../utils/axios";
 import { Team, TeamsShowResponse, User } from "../types";
@@ -58,16 +58,30 @@ const TeamsShow: FC = () => {
         </Grid>
         {users?.map((user) => (
           <Grid item key={user.id}>
-            <Grid container direction="row" justifyContent="space-between">
+            <Grid
+              container
+              direction="row"
+              justifyContent="space-between"
+              alignItems="center"
+            >
               <Grid item>
-                <Button
-                  variant="text"
-                  size="large"
-                  component={Link}
-                  to={`/users/${user.id}`}
+                <Grid
+                  container
+                  direction="column"
+                  justifyContent="center"
+                  alignItems="center"
+                  sx={{ width: 100, height: 120, mr: 2 }}
                 >
-                  {user.name}
-                </Button>
+                  <Avatar sx={{ width: 56, height: 56 }} />
+                  <Button
+                    variant="text"
+                    size="large"
+                    component={Link}
+                    to={`/users/${user.id}`}
+                  >
+                    {user.name}
+                  </Button>
+                </Grid>
               </Grid>
               <Grid item>
                 <TasksBar user={user} maxCount={maxCount} />

--- a/frontend/src/pages/TeamsShow.tsx
+++ b/frontend/src/pages/TeamsShow.tsx
@@ -72,7 +72,15 @@ const TeamsShow: FC = () => {
                   alignItems="center"
                   sx={{ width: 100, height: 120, mr: 2 }}
                 >
-                  <Avatar sx={{ width: 56, height: 56 }} />
+                  {user.avatar ? (
+                    <Avatar
+                      src={user.avatar}
+                      alt="avatar"
+                      sx={{ width: 60, height: 60 }}
+                    />
+                  ) : (
+                    <Avatar sx={{ width: 60, height: 60 }} />
+                  )}
                   <Button
                     variant="text"
                     size="large"

--- a/frontend/src/pages/TeamsShow.tsx
+++ b/frontend/src/pages/TeamsShow.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, FC } from "react";
 import { useParams, Link } from "react-router-dom";
 import Cookies from "js-cookie";
-import { Button, Grid, Typography } from "@mui/material";
+import { Button, Divider, Grid, Typography } from "@mui/material";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { axiosInstance } from "../utils/axios";
 import { Team, TeamsShowResponse, User } from "../types";
@@ -56,14 +56,9 @@ const TeamsShow: FC = () => {
             {team?.name ? `${team.name}のタスク` : ""}
           </Typography>
         </Grid>
-        <Grid item>
-          {users?.map((user) => (
-            <Grid
-              container
-              direction="row"
-              justifyContent="space-between"
-              key={user.id}
-            >
+        {users?.map((user) => (
+          <Grid item key={user.id}>
+            <Grid container direction="row" justifyContent="space-between">
               <Grid item>
                 <Button
                   variant="text"
@@ -78,8 +73,9 @@ const TeamsShow: FC = () => {
                 <TasksBar user={user} maxCount={maxCount} />
               </Grid>
             </Grid>
-          ))}
-        </Grid>
+            <Divider />
+          </Grid>
+        ))}
       </Grid>
     </div>
   );

--- a/frontend/src/pages/TeamsShow.tsx
+++ b/frontend/src/pages/TeamsShow.tsx
@@ -50,9 +50,14 @@ const TeamsShow: FC = () => {
 
   return (
     <div>
-      <Grid container direction="column" spacing={3}>
+      <Grid container direction="column" spacing={2}>
         <Grid item>
-          <Typography variant="h4" component="div" data-testid="teams-show-h4">
+          <Typography
+            gutterBottom
+            variant="h4"
+            component="div"
+            data-testid="teams-show-h4"
+          >
             {team?.name ? `${team.name}のタスク` : ""}
           </Typography>
         </Grid>

--- a/frontend/src/pages/UsersEdit.tsx
+++ b/frontend/src/pages/UsersEdit.tsx
@@ -21,7 +21,7 @@ const UsersEdit: FC = () => {
   const { currentUser, setCurrentUser } = useContext(AuthContext);
   const { handleSetSnackbar } = useContext(SnackbarContext);
   const navigate = useNavigate();
-  const { user: userData, avatar } = useFetchUser();
+  const { user: userData } = useFetchUser();
 
   const [user, setUser] = useState<User>({
     team_id: 0,
@@ -36,6 +36,7 @@ const UsersEdit: FC = () => {
     created_at: new Date(),
     updated_at: new Date(),
     unfinished_tasks_count: [0],
+    avatar: "",
   });
 
   const [image, setImage] = useState({
@@ -152,8 +153,8 @@ const UsersEdit: FC = () => {
               </Grid>
             </Grid>
             <Grid item>
-              {avatar ? (
-                <img src={avatar} alt="avatar" width={300} height="auto" />
+              {user.avatar ? (
+                <img src={user.avatar} alt="avatar" width={300} height="auto" />
               ) : (
                 <Typography variant="body1" component="div">
                   設定されていません

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -18,6 +18,7 @@ export type User = {
   created_at: Date;
   updated_at: Date;
   unfinished_tasks_count: number[];
+  avatar: string;
 };
 
 export type Task = {


### PR DESCRIPTION
### 変更内容
**backend**
- `avatar_url`を共通メソッド化
- `teams#show`で`avatar`をレスポンスデータに含むよう修正

**frontend**
- `type User`に`avatar`を追加
- `TeamsShow`ページで`avatar`が存在する場合に表示するよう修正