### PR TITLE
feat: チームの管理者を作成する #135

### DIFF
--- a/backend/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/backend/app/controllers/api/v1/auth/registrations_controller.rb
@@ -24,11 +24,11 @@ class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsCon
   private
 
   def sign_up_params
-    params.permit(:name, :email, :password, :team_id)
+    params.permit(:name, :email, :password, :team_id, :admin)
   end
 
   def account_update_params
-    params.permit(:name, :email, :password, :team_id, :avatar)
+    params.permit(:name, :email, :password, :team_id, :admin, :avatar)
   end
 
   def ensure_normal_user

--- a/backend/app/controllers/api/v1/teams_controller.rb
+++ b/backend/app/controllers/api/v1/teams_controller.rb
@@ -2,6 +2,7 @@ class Api::V1::TeamsController < ApplicationController
   before_action :authenticate_api_v1_user!, except: [:select, :create, :destroy]
   before_action :set_team, only: [:show, :update, :destroy, :ensure_correct_user]
   before_action :ensure_correct_user, except: [:select, :create, :destroy]
+  before_action :ensure_admin_user, only: [:update, :destroy]
 
   def select
     teams = Team.all
@@ -49,13 +50,19 @@ class Api::V1::TeamsController < ApplicationController
     @team = Team.find(params[:id])
   end
 
+  def team_params
+    params.require(:team).permit(:name)
+  end
+
   def ensure_correct_user
     if @team.users.exclude? current_api_v1_user
       render json: { messages: "この操作は出来ません" }, status: :internal_server_error
     end
   end
 
-  def team_params
-    params.require(:team).permit(:name)
+  def ensure_admin_user
+    if @team.admin_users.exclude? current_api_v1_user
+      render json: { messages: "管理者権限が必要です" }, status: :internal_server_error
+    end
   end
 end

--- a/backend/app/models/team.rb
+++ b/backend/app/models/team.rb
@@ -2,4 +2,8 @@ class Team < ApplicationRecord
   has_many :users, dependent: :restrict_with_error
 
   validates :name, presence: true, length: { maximum: 20 }
+
+  def admin_users
+    users.where(admin: true)
+  end
 end

--- a/backend/db/migrate/20220901061627_add_admin_to_users.rb
+++ b/backend/db/migrate/20220901061627_add_admin_to_users.rb
@@ -1,0 +1,5 @@
+class AddAdminToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :admin, :boolean, default: false
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_13_051133) do
+ActiveRecord::Schema.define(version: 2022_09_01_061627) do
 
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -91,6 +91,7 @@ ActiveRecord::Schema.define(version: 2022_06_13_051133) do
     t.string "last_sign_in_ip"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "admin", default: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["team_id"], name: "fk_rails_b2bbf87303"

--- a/backend/spec/factories/users.rb
+++ b/backend/spec/factories/users.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     name { Faker::Name.name }
     email { Faker::Internet.unique.email }
     password { Faker::Internet.password(min_length: 8) }
+    admin { false }
   end
 end

--- a/backend/spec/models/team_spec.rb
+++ b/backend/spec/models/team_spec.rb
@@ -9,4 +9,18 @@ RSpec.describe Team, type: :model do
       expect(team.errors).to be_of_kind(:name, :blank)
     end
   end
+
+  describe "admin_users method" do
+    let(:team) { create(:team) }
+    let!(:user_admin) { create(:user, team:, admin: true) }
+    let!(:user_normal) { create(:user, team:) }
+
+    it "管理者ユーザーを抽出出来ること" do
+      expect(team.admin_users).to include(user_admin)
+    end
+
+    it "一般ユーザーが含まれていないこと" do
+      expect(team.admin_users).not_to include(user_normal)
+    end
+  end
 end

--- a/frontend/src/mocks/mockUser.ts
+++ b/frontend/src/mocks/mockUser.ts
@@ -21,6 +21,8 @@ export const mockUser: ResponseResolver<MockedRequest, typeof restContext> = (
         created_at: "2022-06-05T10:16:09.882+09:00",
         updated_at: "2022-06-05T10:16:09.882+09:00",
         unfinished_tasks_count: [1, 2, 3],
+        avatar: "",
+        admin: false,
       },
       unfinished_tasks: [
         {
@@ -75,6 +77,8 @@ export const mockUserEdit: ResponseResolver<
         created_at: "2022-06-05T10:16:09.882+09:00",
         updated_at: "2022-06-05T10:16:09.882+09:00",
         unfinished_tasks_count: [1, 2, 3],
+        avatar: "",
+        admin: false,
       },
     })
   );

--- a/frontend/src/pages/DivisionsNew.tsx
+++ b/frontend/src/pages/DivisionsNew.tsx
@@ -5,7 +5,7 @@ import { Button, Grid, MenuItem, TextField, Typography } from "@mui/material";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { axiosInstance } from "../utils/axios";
 import {
-  divisionTask,
+  DivisionTask,
   DivisionsCreateResponse,
   DivisionsNewResponse,
   User,
@@ -19,7 +19,7 @@ const DivisionsNew: FC = () => {
   const params = useParams<{ id: string }>();
   const navigate = useNavigate();
 
-  const [task, setTask] = useState<divisionTask>({
+  const [task, setTask] = useState<DivisionTask>({
     title: "",
     description: "",
     parent_id: 0,

--- a/frontend/src/pages/TasksEdit.tsx
+++ b/frontend/src/pages/TasksEdit.tsx
@@ -4,7 +4,7 @@ import Cookies from "js-cookie";
 import { Button, Grid, TextField, Typography } from "@mui/material";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { axiosInstance } from "../utils/axios";
-import { TasksResponse, editTask } from "../types";
+import { TasksResponse, EditTask } from "../types";
 import { AuthContext } from "../providers/AuthProvider";
 import { useFetchTask } from "../hooks/useFetchTask";
 import { PriorityTextField } from "../components/PriorityTextField";
@@ -18,7 +18,7 @@ const TasksEdit: FC = () => {
   const params = useParams<{ id: string }>();
   const data = useFetchTask();
 
-  const [task, setTask] = useState<editTask>({
+  const [task, setTask] = useState<EditTask>({
     title: "",
     description: "",
     is_done: false,

--- a/frontend/src/pages/TasksNew.tsx
+++ b/frontend/src/pages/TasksNew.tsx
@@ -4,7 +4,7 @@ import Cookies from "js-cookie";
 import { Button, Grid, TextField, Typography } from "@mui/material";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { axiosInstance } from "../utils/axios";
-import { TasksResponse, newTask } from "../types";
+import { TasksResponse, NewTask } from "../types";
 import { AuthContext } from "../providers/AuthProvider";
 import { PriorityTextField } from "../components/PriorityTextField";
 import { DeadlineTextField } from "../components/DeadlineTextField";
@@ -15,7 +15,7 @@ const TasksNew: FC = () => {
   const { handleSetSnackbar } = useContext(SnackbarContext);
   const navigate = useNavigate();
 
-  const [task, setTask] = useState<newTask>({
+  const [task, setTask] = useState<NewTask>({
     title: "",
     description: "",
     is_done: false,

--- a/frontend/src/pages/UsersEdit.tsx
+++ b/frontend/src/pages/UsersEdit.tsx
@@ -37,6 +37,7 @@ const UsersEdit: FC = () => {
     updated_at: new Date(),
     unfinished_tasks_count: [0],
     avatar: "",
+    admin: false,
   });
 
   const [image, setImage] = useState({

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -19,6 +19,7 @@ export type User = {
   updated_at: Date;
   unfinished_tasks_count: number[];
   avatar: string;
+  admin: boolean;
 };
 
 export type Task = {
@@ -41,25 +42,6 @@ export type Division = {
   created_at: Date;
   updated_at: Date;
   comment: string;
-};
-
-export type editUser = {
-  id: number;
-  provider: string;
-  uid: string;
-  allow_password_change: boolean;
-  name: string;
-  nickname: string;
-  image: string;
-  email: string;
-  team_id: number;
-  created_at: Date;
-  updated_at: Date;
-  unfinished_tasks_count: number[];
-  avatar: {
-    data: string;
-    filename: string;
-  };
 };
 
 export type newTask = {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -44,26 +44,26 @@ export type Division = {
   comment: string;
 };
 
-export type newTask = {
+export type NewTask = {
   title: string;
   description: string;
   is_done: boolean;
 };
 
-export type editTask = {
+export type EditTask = {
   title: string;
   description: string;
   is_done: boolean;
   user_id: number;
 };
 
-export type divisionTask = {
+export type DivisionTask = {
   title: string;
   description: string;
   parent_id: number;
 };
 
-export type newDivision = {
+export type NewDivision = {
   comment: string;
 };
 


### PR DESCRIPTION
### 変更内容
**backend**
- `User`テーブルに`admin`カラムを追加
- `admin_users`メソッドの作成
- `ensure_admin_user`アクションの作成
- RSpec作成

**frontend**
- `type User`に`admin`を追加