### PR TITLE
feat: 新規チーム作成フォームの作成 #137

### DIFF
--- a/backend/app/models/team.rb
+++ b/backend/app/models/team.rb
@@ -2,6 +2,7 @@ class Team < ApplicationRecord
   has_many :users, dependent: :restrict_with_error
 
   validates :name, presence: true, length: { maximum: 20 }
+  validates :max_num_of_users, numericality: { in: 1..20 }
 
   def admin_users
     users.where(admin: true)

--- a/backend/db/migrate/20220901124101_add_max_num_of_users_to_teams.rb
+++ b/backend/db/migrate/20220901124101_add_max_num_of_users_to_teams.rb
@@ -1,0 +1,5 @@
+class AddMaxNumOfUsersToTeams < ActiveRecord::Migration[6.1]
+  def change
+    add_column :teams, :max_num_of_users, :integer, default: 10
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_01_061627) do
+ActiveRecord::Schema.define(version: 2022_09_01_124101) do
 
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -68,6 +68,7 @@ ActiveRecord::Schema.define(version: 2022_09_01_061627) do
     t.string "name", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "max_num_of_users", default: 10
   end
 
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|

--- a/backend/spec/factories/teams.rb
+++ b/backend/spec/factories/teams.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :team do
     name { Faker::Team.name }
+    max_num_of_users { 10 }
   end
 end

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -1,12 +1,13 @@
 import { rest } from "msw";
 import { mockSignIn, mockAuthSessions, mockGuestSignIn } from "./mockAuth";
 import { mockDivisionCreate, mockDivisionNew } from "./mockDivision";
-import { mockTeam } from "./mockTeam";
+import { mockTeam, mockTeamCreate } from "./mockTeam";
 import { mockTeams } from "./mockTeams";
 import { mockUser, mockUserEdit } from "./mockUser";
 
 export const handlers = [
   rest.get("/teams/select", mockTeams),
+  rest.post("/teams", mockTeamCreate),
   rest.post("/auth/sign_in", mockSignIn),
   rest.get("/auth/sessions", mockAuthSessions),
   rest.post("/auth/guest_sign_in", mockGuestSignIn),

--- a/frontend/src/mocks/mockTeam.ts
+++ b/frontend/src/mocks/mockTeam.ts
@@ -13,6 +13,7 @@ export const mockTeam: ResponseResolver<MockedRequest, typeof restContext> = (
         name: "TEAM_1",
         created_at: "2022-06-05T10:16:09.882+09:00",
         updated_at: "2022-06-05T10:16:09.882+09:00",
+        max_num_of_users: 10,
       },
       users: [
         {
@@ -44,6 +45,24 @@ export const mockTeam: ResponseResolver<MockedRequest, typeof restContext> = (
           unfinished_tasks_count: [2, 3, 1],
         },
       ],
+    })
+  );
+};
+
+export const mockTeamCreate: ResponseResolver<
+  MockedRequest,
+  typeof restContext
+> = (req, res, ctx) => {
+  return res(
+    ctx.status(201),
+    ctx.json({
+      team: {
+        id: 3,
+        name: "TEAM_NEW",
+        created_at: "2022-06-05T10:16:09.882+09:00",
+        updated_at: "2022-06-05T10:16:09.882+09:00",
+        max_num_of_users: 10,
+      },
     })
   );
 };

--- a/frontend/src/mocks/mockTeams.ts
+++ b/frontend/src/mocks/mockTeams.ts
@@ -14,12 +14,14 @@ export const mockTeams: ResponseResolver<MockedRequest, typeof restContext> = (
           name: "TEAM_1",
           created_at: "2022-06-05T10:16:09.882+09:00",
           updated_at: "2022-06-05T10:16:09.882+09:00",
+          max_num_of_users: 10,
         },
         {
           id: 2,
           name: "TEAM_2",
           created_at: "2022-06-05T10:16:11.169+09:00",
           updated_at: "2022-06-05T10:16:11.169+09:00",
+          max_num_of_users: 10,
         },
       ],
     })

--- a/frontend/src/pages/SignUp.tsx
+++ b/frontend/src/pages/SignUp.tsx
@@ -11,6 +11,7 @@ import { SnackbarContext } from "../providers/SnackbarProvider";
 type State = {
   teamId: number;
   teamName: string;
+  isAdmin: boolean;
 };
 
 const SignUp: FC = () => {
@@ -19,7 +20,7 @@ const SignUp: FC = () => {
   const navigate = useNavigate();
 
   const location = useLocation();
-  const { teamId, teamName } = location.state as State;
+  const { teamId, teamName, isAdmin } = location.state as State;
 
   const [name, setName] = useState<string>("");
   const [email, setEmail] = useState<string>("");
@@ -34,6 +35,7 @@ const SignUp: FC = () => {
         email,
         password,
         team_id: teamId,
+        admin: isAdmin,
       },
     };
 

--- a/frontend/src/pages/TeamsSelect.tsx
+++ b/frontend/src/pages/TeamsSelect.tsx
@@ -74,16 +74,41 @@ const TeamsSelect: FC = () => {
           </TextField>
         </Grid>
         <Grid item>
-          <Link
-            style={{ textDecoration: "none" }}
-            to="/sign_up"
-            key={teamId}
-            state={{ teamId, teamName }}
-          >
-            <Button variant="contained" type="button">
+          <Button variant="contained" type="button">
+            <Link
+              style={{ textDecoration: "none", color: "white" }}
+              to="/sign_up"
+              key={teamId}
+              state={{ teamId, teamName }}
+            >
               次へ
-            </Button>
-          </Link>
+            </Link>
+          </Button>
+        </Grid>
+        <Grid item>
+          <Typography
+            variant="subtitle1"
+            component="div"
+            sx={{ my: 2, ml: 13 }}
+          >
+            または
+          </Typography>
+        </Grid>
+        <Grid item>
+          <Typography variant="h4" component="div" gutterBottom>
+            新規チーム作成
+          </Typography>
+          <Typography variant="subtitle1" component="div">
+            ユーザーはこのチームの管理者となります。
+          </Typography>
+        </Grid>
+        <Grid item>
+          <TextField type="text" label="新規チーム名" sx={{ width: "25ch" }} />
+        </Grid>
+        <Grid item>
+          <Button variant="contained" type="button">
+            作成
+          </Button>
         </Grid>
       </Grid>
     </div>

--- a/frontend/src/pages/TeamsSelect.tsx
+++ b/frontend/src/pages/TeamsSelect.tsx
@@ -1,17 +1,75 @@
 import { ChangeEvent, FC, useContext, useEffect, useState } from "react";
-import { Link, Navigate } from "react-router-dom";
+import { Link, Navigate, useNavigate } from "react-router-dom";
 import { Button, Grid, MenuItem, TextField, Typography } from "@mui/material";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { axiosInstance } from "../utils/axios";
-import { Team, TeamsSelectResponse } from "../types";
+import { Team, TeamsCreateResponse, TeamsSelectResponse } from "../types";
 import { AuthContext } from "../providers/AuthProvider";
+import { SnackbarContext } from "../providers/SnackbarProvider";
 
 const TeamsSelect: FC = () => {
+  const { isSignedIn, currentUser } = useContext(AuthContext);
+  const { handleSetSnackbar } = useContext(SnackbarContext);
+  const navigate = useNavigate();
+
   const [teams, setTeams] = useState<Team[]>([]);
   const [teamId, setTeamId] = useState<string>("");
   const [teamName, setTeamName] = useState<string>("");
+  const [newTeamName, setNewTeamName] = useState<string>("");
 
-  const { isSignedIn, currentUser } = useContext(AuthContext);
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const { value } = event.target;
+    setTeamId(value);
+
+    const teamIdNumber = Number(value);
+    const selectTeam: Team | undefined = teams.find(
+      (v) => v.id === teamIdNumber
+    );
+    console.log(selectTeam);
+
+    if (selectTeam) {
+      setTeamName(selectTeam.name);
+    }
+  };
+
+  const handleTeamsCreate = () => {
+    const teamsCreateOptions: AxiosRequestConfig = {
+      url: "/teams",
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      data: { name: newTeamName },
+    };
+
+    axiosInstance(teamsCreateOptions)
+      .then((res: AxiosResponse<TeamsCreateResponse>) => {
+        console.log(res);
+
+        if (res.status === 201) {
+          handleSetSnackbar({
+            open: true,
+            type: "success",
+            message: "チームを作成しました",
+          });
+          navigate("/sign_up", {
+            state: {
+              teamId: res.data.team.id,
+              teamName: res.data.team.name,
+            },
+          });
+        }
+      })
+      .catch((err) => {
+        console.log(err);
+        handleSetSnackbar({
+          open: true,
+          type: "error",
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+          message: `${err.response.data.messages.join("。")}`,
+        });
+      });
+  };
 
   const options: AxiosRequestConfig = {
     url: "/teams/select",
@@ -29,21 +87,6 @@ const TeamsSelect: FC = () => {
       });
   }, []);
 
-  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
-    const { value } = event.target;
-    setTeamId(value);
-
-    const teamIdNumber = Number(value);
-    const selectTeam: Team | undefined = teams.find(
-      (v) => v.id === teamIdNumber
-    );
-    console.log(selectTeam);
-
-    if (selectTeam) {
-      setTeamName(selectTeam.name);
-    }
-  };
-
   return (
     <div>
       {isSignedIn && <Navigate to={`/teams/${currentUser?.team_id}`} />}
@@ -53,7 +96,7 @@ const TeamsSelect: FC = () => {
             所属チームの選択
           </Typography>
           <Typography variant="subtitle1" component="div">
-            選択したチームのユーザーを作成します。
+            選択したチームでユーザー登録します。
           </Typography>
         </Grid>
         <Grid item>
@@ -99,14 +142,20 @@ const TeamsSelect: FC = () => {
             新規チーム作成
           </Typography>
           <Typography variant="subtitle1" component="div">
-            ユーザーはこのチームの管理者となります。
+            新しいチームの管理者としてユーザー登録します。
           </Typography>
         </Grid>
         <Grid item>
-          <TextField type="text" label="新規チーム名" sx={{ width: "25ch" }} />
+          <TextField
+            type="text"
+            label="新規チーム名"
+            value={newTeamName}
+            onChange={(event) => setNewTeamName(event.target.value)}
+            sx={{ width: "25ch" }}
+          />
         </Grid>
         <Grid item>
-          <Button variant="contained" type="button">
+          <Button type="submit" variant="contained" onClick={handleTeamsCreate}>
             作成
           </Button>
         </Grid>

--- a/frontend/src/pages/TeamsSelect.tsx
+++ b/frontend/src/pages/TeamsSelect.tsx
@@ -56,6 +56,7 @@ const TeamsSelect: FC = () => {
             state: {
               teamId: res.data.team.id,
               teamName: res.data.team.name,
+              isAdmin: true,
             },
           });
         }
@@ -122,7 +123,7 @@ const TeamsSelect: FC = () => {
               style={{ textDecoration: "none", color: "white" }}
               to="/sign_up"
               key={teamId}
-              state={{ teamId, teamName }}
+              state={{ teamId, teamName, isAdmin: false }}
             >
               次へ
             </Link>

--- a/frontend/src/tests/TeamsSelect.test.tsx
+++ b/frontend/src/tests/TeamsSelect.test.tsx
@@ -1,9 +1,14 @@
+/* eslint-disable testing-library/no-unnecessary-act */
 import renderer from "react-test-renderer";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { act } from "react-dom/test-utils";
-import { BrowserRouter } from "react-router-dom";
+import { BrowserRouter, MemoryRouter, Route, Routes } from "react-router-dom";
 import TeamsSelect from "../pages/TeamsSelect";
+import { SnackbarProvider } from "../providers/SnackbarProvider";
+import SignUp from "../pages/SignUp";
+import { AuthProvider } from "../providers/AuthProvider";
+import CommonLayout from "../components/CommonLayout";
 
 describe("TeamsSelect", () => {
   test("スナップショット", () => {
@@ -19,14 +24,33 @@ describe("TeamsSelect", () => {
 
   test("チーム一覧の表示", async () => {
     render(<TeamsSelect />, { wrapper: BrowserRouter });
-    const teamInput = screen.getByLabelText("チーム");
-
-    // eslint-disable-next-line testing-library/no-unnecessary-act
     act(() => {
-      userEvent.click(teamInput);
+      userEvent.click(screen.getByLabelText("チーム"));
     });
-
     expect(await screen.findByText("TEAM_1")).toBeInTheDocument();
     expect(await screen.findByText("TEAM_2")).toBeInTheDocument();
+  });
+
+  test("新規チーム作成", async () => {
+    render(
+      <MemoryRouter initialEntries={["/sign_up/teams/select"]}>
+        <AuthProvider>
+          <SnackbarProvider>
+            <CommonLayout>
+              <Routes>
+                <Route path="/sign_up/teams/select" element={<TeamsSelect />} />
+                <Route path="/sign_up" element={<SignUp />} />
+              </Routes>
+            </CommonLayout>
+          </SnackbarProvider>
+        </AuthProvider>
+      </MemoryRouter>
+    );
+
+    act(() => {
+      userEvent.type(screen.getByLabelText("新規チーム名"), "TEAM_NEW");
+      userEvent.click(screen.getByRole("button", { name: "作成" }));
+    });
+    expect(await screen.findByText("TEAM_NEW")).toBeInTheDocument();
   });
 });

--- a/frontend/src/tests/__snapshots__/TeamsSelect.test.tsx.snap
+++ b/frontend/src/tests/__snapshots__/TeamsSelect.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`TeamsSelect スナップショット 1`] = `
       <div
         className="MuiTypography-root MuiTypography-subtitle1 css-10wpov9-MuiTypography-root"
       >
-        選択したチームのユーザーを作成します。
+        選択したチームでユーザー登録します。
       </div>
     </div>
     <div
@@ -98,36 +98,132 @@ exports[`TeamsSelect スナップショット 1`] = `
     <div
       className="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
     >
-      <a
-        href="/sign_up"
-        onClick={[Function]}
-        style={
-          Object {
-            "textDecoration": "none",
-          }
-        }
+      <button
+        className="MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root  css-sghohy-MuiButtonBase-root-MuiButton-root"
+        disabled={false}
+        onBlur={[Function]}
+        onContextMenu={[Function]}
+        onDragLeave={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
+        tabIndex={0}
+        type="button"
       >
-        <button
-          className="MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root  css-sghohy-MuiButtonBase-root-MuiButton-root"
-          disabled={false}
-          onBlur={[Function]}
-          onContextMenu={[Function]}
-          onDragLeave={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-          onTouchEnd={[Function]}
-          onTouchMove={[Function]}
-          onTouchStart={[Function]}
-          tabIndex={0}
-          type="button"
+        <a
+          href="/sign_up"
+          onClick={[Function]}
+          style={
+            Object {
+              "color": "white",
+              "textDecoration": "none",
+            }
+          }
         >
           次へ
-        </button>
-      </a>
+        </a>
+      </button>
+    </div>
+    <div
+      className="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+    >
+      <div
+        className="MuiTypography-root MuiTypography-subtitle1 css-iehxsa-MuiTypography-root"
+      >
+        または
+      </div>
+    </div>
+    <div
+      className="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+    >
+      <div
+        className="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom css-1vw6mcs-MuiTypography-root"
+      >
+        新規チーム作成
+      </div>
+      <div
+        className="MuiTypography-root MuiTypography-subtitle1 css-10wpov9-MuiTypography-root"
+      >
+        新しいチームの管理者としてユーザー登録します。
+      </div>
+    </div>
+    <div
+      className="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+    >
+      <div
+        className="MuiFormControl-root MuiTextField-root css-ygea6l-MuiFormControl-root-MuiTextField-root"
+      >
+        <label
+          className="MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-root MuiFormLabel-colorPrimary css-14s5rfu-MuiFormLabel-root-MuiInputLabel-root"
+          data-shrink={false}
+          htmlFor=":r1:"
+          id=":r1:-label"
+        >
+          新規チーム名
+        </label>
+        <div
+          className="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+          onClick={[Function]}
+        >
+          <input
+            aria-invalid={false}
+            autoFocus={false}
+            className="MuiOutlinedInput-input MuiInputBase-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
+            disabled={false}
+            id=":r1:"
+            onAnimationStart={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            required={false}
+            type="text"
+            value=""
+          />
+          <fieldset
+            aria-hidden={true}
+            className="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+          >
+            <legend
+              className="css-1ftyaf0"
+            >
+              <span>
+                新規チーム名
+              </span>
+            </legend>
+          </fieldset>
+        </div>
+      </div>
+    </div>
+    <div
+      className="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+    >
+      <button
+        className="MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root  css-sghohy-MuiButtonBase-root-MuiButton-root"
+        disabled={false}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onContextMenu={[Function]}
+        onDragLeave={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
+        tabIndex={0}
+        type="submit"
+      >
+        作成
+      </button>
     </div>
   </div>
 </div>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -3,6 +3,7 @@ export type Team = {
   name: string;
   created_at: Date;
   updated_at: Date;
+  max_num_of_users: number;
 };
 
 export type User = {
@@ -78,6 +79,10 @@ export type AuthResponse = {
 
 export type TeamsSelectResponse = {
   teams: Team[];
+};
+
+export type TeamsCreateResponse = {
+  team: Team;
 };
 
 export type TeamsShowResponse = {


### PR DESCRIPTION
### 変更内容
**backend**
-  `Teams`テーブルに`max_num_of_users`カラムを追加
- `ensure_max_num_of_users`アクションを追加
- テスト作成

**frontend**
-  `TeamsSelect`ページにチーム名入力フォーム、作成ボタンを追加
- チーム作成処理の追加
-  `State`に`isAdmin`を追加
-  テスト作成