### PR TITLE
feat: タスク削除処理の実装 #142

### DIFF
--- a/frontend/src/components/AlertDialog.tsx
+++ b/frontend/src/components/AlertDialog.tsx
@@ -1,0 +1,41 @@
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+} from "@mui/material";
+
+type Props = {
+  open: boolean;
+  handleClose: () => void;
+};
+
+export const AlertDialog = (props: Props) => {
+  const { open, handleClose } = props;
+
+  return (
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      aria-labelledby="alert-dialog-title"
+      aria-describedby="alert-dialog-description"
+    >
+      <DialogTitle id="alert-dialog-title">タスクを削除しますか？</DialogTitle>
+      <DialogContent>
+        <DialogContentText id="alert-dialog-description">
+          削除したタスクは元に戻せません。
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button color="error" onClick={handleClose}>
+          削除する
+        </Button>
+        <Button color="secondary" onClick={handleClose} autoFocus>
+          戻る
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/frontend/src/components/AlertDialog.tsx
+++ b/frontend/src/components/AlertDialog.tsx
@@ -1,3 +1,6 @@
+import { useContext } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import Cookies from "js-cookie";
 import {
   Button,
   Dialog,
@@ -6,6 +9,10 @@ import {
   DialogContentText,
   DialogTitle,
 } from "@mui/material";
+import { AxiosRequestConfig, AxiosResponse } from "axios";
+import { axiosInstance } from "../utils/axios";
+import { AuthContext } from "../providers/AuthProvider";
+import { SnackbarContext } from "../providers/SnackbarProvider";
 
 type Props = {
   open: boolean;
@@ -13,7 +20,46 @@ type Props = {
 };
 
 export const AlertDialog = (props: Props) => {
+  const { currentUser } = useContext(AuthContext);
+  const { handleSetSnackbar } = useContext(SnackbarContext);
+  const navigate = useNavigate();
+  const params = useParams<{ id: string }>();
   const { open, handleClose } = props;
+
+  const handleTasksDelete = () => {
+    const options: AxiosRequestConfig = {
+      url: `/tasks/${params.id}`,
+      method: "DELETE",
+      headers: {
+        "access-token": Cookies.get("_access_token") || "",
+        client: Cookies.get("_client") || "",
+        uid: Cookies.get("_uid") || "",
+      },
+    };
+
+    axiosInstance(options)
+      .then((res: AxiosResponse) => {
+        console.log(res);
+
+        if (res.status === 200) {
+          handleSetSnackbar({
+            open: true,
+            type: "success",
+            message: "タスクを削除しました",
+          });
+          navigate(`/users/${currentUser?.id}`, { replace: true });
+        }
+      })
+      .catch((err) => {
+        console.log(err);
+        handleSetSnackbar({
+          open: true,
+          type: "error",
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+          message: `${err.response.data.errors}`,
+        });
+      });
+  };
 
   return (
     <Dialog
@@ -29,7 +75,7 @@ export const AlertDialog = (props: Props) => {
         </DialogContentText>
       </DialogContent>
       <DialogActions>
-        <Button color="error" onClick={handleClose}>
+        <Button color="error" onClick={handleTasksDelete}>
           削除する
         </Button>
         <Button color="secondary" onClick={handleClose} autoFocus>

--- a/frontend/src/components/DeadlineFormat.tsx
+++ b/frontend/src/components/DeadlineFormat.tsx
@@ -1,0 +1,9 @@
+import { format } from "date-fns";
+
+export const DeadlineFormat = (date: Date | undefined) => {
+  if (date) {
+    return <div>{format(new Date(date), "yyyy/MM/dd HH:mm")}</div>;
+  }
+
+  return <div> </div>;
+};

--- a/frontend/src/components/PriorityLabel.tsx
+++ b/frontend/src/components/PriorityLabel.tsx
@@ -1,0 +1,12 @@
+export const PriorityLabel = (value: string | undefined) => {
+  switch (value) {
+    case "high":
+      return "高";
+    case "medium":
+      return "中";
+    case "low":
+      return "低";
+    default:
+      return "";
+  }
+};

--- a/frontend/src/components/TasksTable.tsx
+++ b/frontend/src/components/TasksTable.tsx
@@ -12,12 +12,12 @@ import {
   TableHead,
   TableRow,
 } from "@mui/material";
-import { format } from "date-fns";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { axiosInstance } from "../utils/axios";
 import { Task, User, TasksResponse } from "../types";
 import { AuthContext } from "../providers/AuthProvider";
 import { PriorityLabel } from "./PriorityLabel";
+import { DeadlineFormat } from "./DeadlineFormat";
 
 type Props = {
   user: User | undefined;
@@ -82,9 +82,7 @@ export const TasksTable = (props: Props) => {
               <TableCell>
                 <Link to={`/tasks/${task.id}`}>{task.title}</Link>
               </TableCell>
-              <TableCell>
-                {format(new Date(task.deadline), "yyyy/MM/dd HH:mm")}
-              </TableCell>
+              <TableCell>{DeadlineFormat(task.deadline)}</TableCell>
               <TableCell align="center">
                 {PriorityLabel(task.priority)}
               </TableCell>

--- a/frontend/src/components/TasksTable.tsx
+++ b/frontend/src/components/TasksTable.tsx
@@ -2,8 +2,8 @@ import { Dispatch, SetStateAction, useContext } from "react";
 import { Link } from "react-router-dom";
 import Cookies from "js-cookie";
 import {
-  Button,
   Checkbox,
+  IconButton,
   Paper,
   Table,
   TableBody,
@@ -11,7 +11,9 @@ import {
   TableContainer,
   TableHead,
   TableRow,
+  Tooltip,
 } from "@mui/material";
+import SendIcon from "@mui/icons-material/Send";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { axiosInstance } from "../utils/axios";
 import { Task, User, TasksResponse } from "../types";
@@ -55,7 +57,10 @@ export const TasksTable = (props: Props) => {
 
   return (
     <TableContainer component={Paper}>
-      <Table sx={{ width: 850 }} aria-label="tasks table">
+      <Table
+        sx={{ width: { xs: 200, sm: 500, md: 700, lg: 900 } }}
+        aria-label="tasks table"
+      >
         <TableHead>
           <TableRow>
             {user?.id === currentUser?.id && (
@@ -88,12 +93,19 @@ export const TasksTable = (props: Props) => {
               </TableCell>
               {!isFinished && (
                 <TableCell align="center">
-                  <Button
-                    component={Link}
-                    to={`/tasks/${task.id}/divisions/new`}
+                  <Tooltip
+                    color="secondary"
+                    title="分担する"
+                    placement="top"
+                    arrow
                   >
-                    分担する
-                  </Button>
+                    <IconButton
+                      component={Link}
+                      to={`/tasks/${task.id}/divisions/new`}
+                    >
+                      <SendIcon />
+                    </IconButton>
+                  </Tooltip>
                 </TableCell>
               )}
             </TableRow>

--- a/frontend/src/components/TasksTable.tsx
+++ b/frontend/src/components/TasksTable.tsx
@@ -17,6 +17,7 @@ import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { axiosInstance } from "../utils/axios";
 import { Task, User, TasksResponse } from "../types";
 import { AuthContext } from "../providers/AuthProvider";
+import { PriorityLabel } from "./PriorityLabel";
 
 type Props = {
   user: User | undefined;
@@ -28,19 +29,6 @@ type Props = {
 export const TasksTable = (props: Props) => {
   const { user, tasks, setTasks, isFinished } = props;
   const { currentUser } = useContext(AuthContext);
-
-  const displayLabel = (value: string) => {
-    switch (value) {
-      case "high":
-        return "高";
-      case "medium":
-        return "中";
-      case "low":
-        return "低";
-      default:
-        return "";
-    }
-  };
 
   const handleIsDoneUpdate = (id: number, index: number) => {
     const isDone = tasks[index].is_done;
@@ -98,7 +86,7 @@ export const TasksTable = (props: Props) => {
                 {format(new Date(task.deadline), "yyyy/MM/dd HH:mm")}
               </TableCell>
               <TableCell align="center">
-                {displayLabel(task.priority)}
+                {PriorityLabel(task.priority)}
               </TableCell>
               {!isFinished && (
                 <TableCell align="center">

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -1,6 +1,7 @@
 import { rest } from "msw";
 import { mockSignIn, mockAuthSessions, mockGuestSignIn } from "./mockAuth";
 import { mockDivisionCreate, mockDivisionNew } from "./mockDivision";
+import { mockTask } from "./mockTask";
 import { mockTeam, mockTeamCreate } from "./mockTeam";
 import { mockTeams } from "./mockTeams";
 import { mockUser, mockUserEdit } from "./mockUser";
@@ -16,4 +17,6 @@ export const handlers = [
   rest.patch("/auth", mockUserEdit),
   rest.get("/tasks/:id/divisions/new", mockDivisionNew),
   rest.post("/tasks/:id/divisions", mockDivisionCreate),
+  rest.get("/tasks/:id", mockTask),
+  rest.delete("/tasks/:id", mockTask),
 ];

--- a/frontend/src/mocks/mockTask.ts
+++ b/frontend/src/mocks/mockTask.ts
@@ -1,0 +1,25 @@
+import { MockedRequest, ResponseResolver, restContext } from "msw";
+
+export const mockTask: ResponseResolver<MockedRequest, typeof restContext> = (
+  req,
+  res,
+  ctx
+) => {
+  return res(
+    ctx.status(200),
+    ctx.json({
+      task: {
+        id: 1,
+        title: "TASK_1",
+        description: "TASKTASK",
+        deadline: "2022-08-31T12:00:20.000+09:00",
+        priority: "medium",
+        is_done: false,
+        user_id: 1,
+        created_at: "2022-08-26T17:02:20.690+09:00",
+        updated_at: "2022-08-26T22:20:34.948+09:00",
+        parent_id: null,
+      },
+    })
+  );
+};

--- a/frontend/src/pages/TasksShow.tsx
+++ b/frontend/src/pages/TasksShow.tsx
@@ -47,7 +47,8 @@ const TasksShow: FC = () => {
             <CardHeader
               title={task?.title}
               action={
-                task?.user_id === currentUser?.id && (
+                task?.user_id === currentUser?.id &&
+                task?.is_done === false && (
                   <Stack direction="row" spacing={1}>
                     <Tooltip title="編集" placement="top" arrow>
                       <IconButton
@@ -113,14 +114,16 @@ const TasksShow: FC = () => {
               </Typography>
             </CardContent>
             <CardActions>
-              <Button
-                variant="contained"
-                type="button"
-                component={Link}
-                to={`/tasks/${task?.id}/divisions/new`}
-              >
-                分担する
-              </Button>
+              {task?.is_done === false && (
+                <Button
+                  variant="contained"
+                  type="button"
+                  component={Link}
+                  to={`/tasks/${task?.id}/divisions/new`}
+                >
+                  分担する
+                </Button>
+              )}
             </CardActions>
           </Card>
         </Grid>

--- a/frontend/src/pages/TasksShow.tsx
+++ b/frontend/src/pages/TasksShow.tsx
@@ -5,9 +5,15 @@ import {
   Card,
   CardActions,
   CardContent,
+  CardHeader,
   Grid,
+  IconButton,
+  Stack,
+  Tooltip,
   Typography,
 } from "@mui/material";
+import EditIcon from "@mui/icons-material/Edit";
+import DeleteIcon from "@mui/icons-material/Delete";
 import { useFetchTask } from "../hooks/useFetchTask";
 import { AuthContext } from "../providers/AuthProvider";
 import { PriorityLabel } from "../components/PriorityLabel";
@@ -26,18 +32,30 @@ const TasksShow: FC = () => {
           </Typography>
         </Grid>
         <Grid item>
-          <Card sx={{ width: 700, p: 2 }}>
+          <Card sx={{ minWidth: 500, p: 2 }}>
+            <CardHeader
+              title={task?.title}
+              action={
+                task?.user_id === currentUser?.id && (
+                  <Stack direction="row" spacing={1}>
+                    <Tooltip title="編集" placement="top" arrow>
+                      <IconButton
+                        component={Link}
+                        to={`/tasks/${task?.id}/edit`}
+                      >
+                        <EditIcon />
+                      </IconButton>
+                    </Tooltip>
+                    <Tooltip title="削除" placement="top" arrow>
+                      <IconButton>
+                        <DeleteIcon />
+                      </IconButton>
+                    </Tooltip>
+                  </Stack>
+                )
+              }
+            />
             <CardContent>
-              <Typography
-                variant="subtitle1"
-                component="div"
-                color="text.secondary"
-              >
-                タイトル
-              </Typography>
-              <Typography variant="h5" component="div" sx={{ mb: 2 }}>
-                {task?.title}
-              </Typography>
               <Typography
                 variant="subtitle1"
                 component="div"
@@ -78,17 +96,6 @@ const TasksShow: FC = () => {
               <Typography variant="body1" component="div" sx={{ mb: 2 }}>
                 {task?.is_done.toString()}
               </Typography>
-              {task?.user_id === currentUser?.id && (
-                <Button
-                  variant="outlined"
-                  color="secondary"
-                  type="button"
-                  component={Link}
-                  to={`/tasks/${task?.id}/edit`}
-                >
-                  編集
-                </Button>
-              )}
             </CardContent>
             <CardActions>
               <Button

--- a/frontend/src/pages/TasksShow.tsx
+++ b/frontend/src/pages/TasksShow.tsx
@@ -26,36 +26,56 @@ const TasksShow: FC = () => {
           </Typography>
         </Grid>
         <Grid item>
-          <Card sx={{ width: 700, p: 1 }}>
+          <Card sx={{ width: 700, p: 2 }}>
             <CardContent>
-              <Typography variant="subtitle1" component="div">
+              <Typography
+                variant="subtitle1"
+                component="div"
+                color="text.secondary"
+              >
                 タイトル
               </Typography>
-              <Typography variant="h6" component="div" sx={{ mb: 1.5 }}>
+              <Typography variant="h5" component="div" sx={{ mb: 2 }}>
                 {task?.title}
               </Typography>
-              <Typography variant="subtitle1" component="div">
+              <Typography
+                variant="subtitle1"
+                component="div"
+                color="text.secondary"
+              >
                 詳細
               </Typography>
-              <Typography variant="body1" component="div" sx={{ mb: 1.5 }}>
+              <Typography variant="body1" component="div" sx={{ mb: 2 }}>
                 {task?.description}
               </Typography>
-              <Typography variant="subtitle1" component="div">
+              <Typography
+                variant="subtitle1"
+                component="div"
+                color="text.secondary"
+              >
                 納期
               </Typography>
-              <Typography variant="body1" component="div" sx={{ mb: 1.5 }}>
+              <Typography variant="body1" component="div" sx={{ mb: 2 }}>
                 {DeadlineFormat(task?.deadline)}
               </Typography>
-              <Typography variant="subtitle1" component="div">
+              <Typography
+                variant="subtitle1"
+                component="div"
+                color="text.secondary"
+              >
                 優先度
               </Typography>
-              <Typography variant="body1" component="div" sx={{ mb: 1.5 }}>
+              <Typography variant="body1" component="div" sx={{ mb: 2 }}>
                 {PriorityLabel(task?.priority)}
               </Typography>
-              <Typography variant="subtitle1" component="div">
+              <Typography
+                variant="subtitle1"
+                component="div"
+                color="text.secondary"
+              >
                 完了フラグ
               </Typography>
-              <Typography variant="body1" component="div" sx={{ mb: 1.5 }}>
+              <Typography variant="body1" component="div" sx={{ mb: 2 }}>
                 {task?.is_done.toString()}
               </Typography>
               {task?.user_id === currentUser?.id && (

--- a/frontend/src/pages/TasksShow.tsx
+++ b/frontend/src/pages/TasksShow.tsx
@@ -1,6 +1,13 @@
 import { FC, useContext } from "react";
 import { Link } from "react-router-dom";
-import { Button, Grid, Typography } from "@mui/material";
+import {
+  Button,
+  Card,
+  CardActions,
+  CardContent,
+  Grid,
+  Typography,
+} from "@mui/material";
 import { useFetchTask } from "../hooks/useFetchTask";
 import { AuthContext } from "../providers/AuthProvider";
 import { PriorityLabel } from "../components/PriorityLabel";
@@ -12,74 +19,68 @@ const TasksShow: FC = () => {
 
   return (
     <div>
-      <Grid container direction="column" spacing={2}>
+      <Grid container direction="column" spacing={3}>
         <Grid item>
           <Typography variant="h4" component="div">
             タスク詳細
           </Typography>
         </Grid>
         <Grid item>
-          <Typography variant="subtitle1" component="div">
-            タイトル
-          </Typography>
-          <Typography variant="h6" component="div">
-            {task?.title}
-          </Typography>
-        </Grid>
-        <Grid item>
-          <Typography variant="subtitle1" component="div">
-            詳細
-          </Typography>
-          <Typography variant="body1" component="div">
-            {task?.description}
-          </Typography>
-        </Grid>
-        <Grid item>
-          <Typography variant="subtitle1" component="div">
-            納期
-          </Typography>
-          <Typography variant="body1" component="div">
-            {DeadlineFormat(task?.deadline)}
-          </Typography>
-        </Grid>
-        <Grid item>
-          <Typography variant="subtitle1" component="div">
-            優先度
-          </Typography>
-          <Typography variant="body1" component="div">
-            {PriorityLabel(task?.priority)}
-          </Typography>
-        </Grid>
-        <Grid item>
-          <Typography variant="subtitle1" component="div">
-            完了フラグ
-          </Typography>
-          <Typography variant="body1" component="div">
-            {task?.is_done.toString()}
-          </Typography>
-        </Grid>
-        {task?.user_id === currentUser?.id && (
-          <Grid item>
-            <Button
-              variant="outlined"
-              color="secondary"
-              type="button"
-              component={Link}
-              to={`/tasks/${task?.id}/edit`}
-            >
-              編集
-            </Button>
-          </Grid>
-        )}
-        <Grid item>
-          <Button
-            variant="contained"
-            type="button"
-            component={Link}
-            to={`/tasks/${task?.id}/divisions/new`}
-          >
-            分担する
-          </Button>
+          <Card sx={{ width: 700, p: 1 }}>
+            <CardContent>
+              <Typography variant="subtitle1" component="div">
+                タイトル
+              </Typography>
+              <Typography variant="h6" component="div" sx={{ mb: 1.5 }}>
+                {task?.title}
+              </Typography>
+              <Typography variant="subtitle1" component="div">
+                詳細
+              </Typography>
+              <Typography variant="body1" component="div" sx={{ mb: 1.5 }}>
+                {task?.description}
+              </Typography>
+              <Typography variant="subtitle1" component="div">
+                納期
+              </Typography>
+              <Typography variant="body1" component="div" sx={{ mb: 1.5 }}>
+                {DeadlineFormat(task?.deadline)}
+              </Typography>
+              <Typography variant="subtitle1" component="div">
+                優先度
+              </Typography>
+              <Typography variant="body1" component="div" sx={{ mb: 1.5 }}>
+                {PriorityLabel(task?.priority)}
+              </Typography>
+              <Typography variant="subtitle1" component="div">
+                完了フラグ
+              </Typography>
+              <Typography variant="body1" component="div" sx={{ mb: 1.5 }}>
+                {task?.is_done.toString()}
+              </Typography>
+              {task?.user_id === currentUser?.id && (
+                <Button
+                  variant="outlined"
+                  color="secondary"
+                  type="button"
+                  component={Link}
+                  to={`/tasks/${task?.id}/edit`}
+                >
+                  編集
+                </Button>
+              )}
+            </CardContent>
+            <CardActions>
+              <Button
+                variant="contained"
+                type="button"
+                component={Link}
+                to={`/tasks/${task?.id}/divisions/new`}
+              >
+                分担する
+              </Button>
+            </CardActions>
+          </Card>
         </Grid>
       </Grid>
     </div>

--- a/frontend/src/pages/TasksShow.tsx
+++ b/frontend/src/pages/TasksShow.tsx
@@ -4,6 +4,7 @@ import { Button, Grid, Typography } from "@mui/material";
 import { useFetchTask } from "../hooks/useFetchTask";
 import { AuthContext } from "../providers/AuthProvider";
 import { PriorityLabel } from "../components/PriorityLabel";
+import { DeadlineFormat } from "../components/DeadlineFormat";
 
 const TasksShow: FC = () => {
   const task = useFetchTask();
@@ -38,7 +39,7 @@ const TasksShow: FC = () => {
             納期
           </Typography>
           <Typography variant="body1" component="div">
-            {task?.deadline.toString()}
+            {DeadlineFormat(task?.deadline)}
           </Typography>
         </Grid>
         <Grid item>

--- a/frontend/src/pages/TasksShow.tsx
+++ b/frontend/src/pages/TasksShow.tsx
@@ -58,7 +58,10 @@ const TasksShow: FC = () => {
                       </IconButton>
                     </Tooltip>
                     <Tooltip title="削除" placement="top" arrow>
-                      <IconButton onClick={handleClickOpen}>
+                      <IconButton
+                        onClick={handleClickOpen}
+                        data-testid="delete-button"
+                      >
                         <DeleteIcon />
                       </IconButton>
                     </Tooltip>

--- a/frontend/src/pages/TasksShow.tsx
+++ b/frontend/src/pages/TasksShow.tsx
@@ -1,4 +1,4 @@
-import { FC, useContext } from "react";
+import { FC, useContext, useState } from "react";
 import { Link } from "react-router-dom";
 import {
   Button,
@@ -18,10 +18,21 @@ import { useFetchTask } from "../hooks/useFetchTask";
 import { AuthContext } from "../providers/AuthProvider";
 import { PriorityLabel } from "../components/PriorityLabel";
 import { DeadlineFormat } from "../components/DeadlineFormat";
+import { AlertDialog } from "../components/AlertDialog";
 
 const TasksShow: FC = () => {
-  const task = useFetchTask();
   const { currentUser } = useContext(AuthContext);
+  const task = useFetchTask();
+
+  const [open, setOpen] = useState(false);
+
+  const handleClickOpen = () => {
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
 
   return (
     <div>
@@ -47,10 +58,11 @@ const TasksShow: FC = () => {
                       </IconButton>
                     </Tooltip>
                     <Tooltip title="削除" placement="top" arrow>
-                      <IconButton>
+                      <IconButton onClick={handleClickOpen}>
                         <DeleteIcon />
                       </IconButton>
                     </Tooltip>
+                    <AlertDialog open={open} handleClose={handleClose} />
                   </Stack>
                 )
               }

--- a/frontend/src/pages/TasksShow.tsx
+++ b/frontend/src/pages/TasksShow.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import { Button, Grid, Typography } from "@mui/material";
 import { useFetchTask } from "../hooks/useFetchTask";
 import { AuthContext } from "../providers/AuthProvider";
+import { PriorityLabel } from "../components/PriorityLabel";
 
 const TasksShow: FC = () => {
   const task = useFetchTask();
@@ -45,7 +46,7 @@ const TasksShow: FC = () => {
             優先度
           </Typography>
           <Typography variant="body1" component="div">
-            {task?.priority}
+            {PriorityLabel(task?.priority)}
           </Typography>
         </Grid>
         <Grid item>

--- a/frontend/src/pages/UsersShow.tsx
+++ b/frontend/src/pages/UsersShow.tsx
@@ -69,6 +69,7 @@ const UsersShow: FC = () => {
             <Grid item>
               <Box sx={{ width: "100%" }}>
                 <Tabs
+                  textColor="inherit"
                   value={value}
                   onChange={handleSwitchTasks}
                   aria-label="tabs"

--- a/frontend/src/tests/TasksShow.test.tsx
+++ b/frontend/src/tests/TasksShow.test.tsx
@@ -1,0 +1,80 @@
+/* eslint-disable @typescript-eslint/await-thenable */
+/* eslint-disable testing-library/no-unnecessary-act */
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { rest } from "msw";
+import { act } from "react-dom/test-utils";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import CommonLayout from "../components/CommonLayout";
+import { server } from "../mocks/server";
+import TasksShow from "../pages/TasksShow";
+import UsersShow from "../pages/UsersShow";
+import { AuthProvider } from "../providers/AuthProvider";
+import { SnackbarProvider } from "../providers/SnackbarProvider";
+
+describe("TasksShow", () => {
+  test("タスク詳細ページ", async () => {
+    server.use(
+      rest.get("/auth/sessions", (req, res, ctx) => {
+        return res(
+          ctx.status(200),
+          ctx.json({
+            is_signed_in: true,
+            current_user: {
+              email: "test@example.com",
+              uid: "test@example.com",
+              id: 1,
+              provider: "email",
+              allow_password_change: false,
+              name: "USER_1",
+              nickname: null,
+              image: null,
+              team_id: 1,
+            },
+          })
+        );
+      })
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/tasks/1"]}>
+        <AuthProvider>
+          <SnackbarProvider>
+            <CommonLayout>
+              <Routes>
+                <Route path="/tasks/:id" element={<TasksShow />} />
+                <Route path="/users/:id" element={<UsersShow />} />
+              </Routes>
+            </CommonLayout>
+          </SnackbarProvider>
+        </AuthProvider>
+      </MemoryRouter>
+    );
+
+    // タスクのタイトルが表示されている
+    expect(await screen.findByText("TASK_1")).toBeInTheDocument();
+
+    await act(() => {
+      userEvent.click(screen.getByTestId("delete-button"));
+    });
+
+    // 削除確認ダイアログが開く
+    expect(
+      await screen.findByText("タスクを削除しますか？")
+    ).toBeInTheDocument();
+
+    await act(() => {
+      userEvent.click(screen.getByRole("button", { name: "削除する" }));
+    });
+
+    expect(await screen.findByText("タスクを削除しました")).toBeInTheDocument();
+
+    // ユーザー詳細ページに遷移する
+    expect(await screen.findByText("USER_1のタスク")).toBeInTheDocument();
+
+    // 削除したタスクは表示されていない
+    await waitFor(() => {
+      expect(screen.queryByText("TASK_1")).not.toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
### 変更内容
**frontend**
- `TasksShow`ページにタスク削除ボタンを作成
- `AlertDialog`コンポーネントの作成
- タスク削除処理を追加
- テスト作成