### PR TITLE
feat: パスワード更新処理の実装 #146

### DIFF
--- a/backend/app/controllers/api/v1/auth/passwords_controller.rb
+++ b/backend/app/controllers/api/v1/auth/passwords_controller.rb
@@ -1,6 +1,17 @@
 class Api::V1::Auth::PasswordsController < DeviseTokenAuth::PasswordsController
   before_action :ensure_normal_user, only: [:create, :update]
 
+  protected
+
+  def render_update_success
+    data = resource_data.as_json.merge(avatar: avatar_url(@resource))
+    render json: {
+      success: true,
+      data:,
+      message: I18n.t("devise_token_auth.passwords.successfully_updated")
+    }
+  end
+
   private
 
   def ensure_normal_user

--- a/backend/spec/requests/api/v1/auth/passwords_spec.rb
+++ b/backend/spec/requests/api/v1/auth/passwords_spec.rb
@@ -1,6 +1,21 @@
 require "rails_helper"
 
 RSpec.describe "Api::V1::Auth::Passwords", type: :request do
+  let(:json) { JSON.parse(response.body) }
+
+  describe "PATCH /password" do
+    let(:team) { create(:team) }
+    let(:user) { create(:user, team_id: team.id) }
+    let(:headers) { user.create_new_auth_token }
+    let(:params) { { password: "new_password", password_confirmation: "new_password" } }
+
+    it "レスポンスデータにアバター情報が含まれていること" do
+      patch "/api/v1/auth/password", headers: headers, params: params
+      expect(response).to have_http_status(:ok)
+      expect(json["data"]["avatar"]).to eq ""
+    end
+  end
+
   describe "before_action :ensure_normal_user" do
     let(:guest_headers) do
       {
@@ -9,7 +24,6 @@ RSpec.describe "Api::V1::Auth::Passwords", type: :request do
         "uid" => response.headers["uid"]
       }
     end
-    let(:json) { JSON.parse(response.body) }
 
     before do
       post "/api/v1/auth/guest_sign_in"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
     "@emotion/styled": "^11.9.3",
     "@fontsource/roboto": "^4.5.7",
     "@mui/icons-material": "^5.10.3",
+    "@mui/lab": "^5.0.0-alpha.97",
     "@mui/material": "^5.9.0",
     "@mui/x-date-pickers": "^5.0.0-beta.1",
     "@testing-library/react": "^13.0.0",

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -5,6 +5,7 @@ import {
   mockGuestSignIn,
   mockAuthDelete,
   mockAuthUpdate,
+  mockAuthPasswordsUpdate,
 } from "./mockAuth";
 import { mockDivisionsCreate, mockDivisionsNew } from "./mockDivisions";
 import { mockTasksShow } from "./mockTasks";
@@ -15,6 +16,7 @@ export const handlers = [
   rest.get("/auth/sessions", mockAuthSessions),
   rest.post("/auth/sign_in", mockSignIn),
   rest.post("/auth/guest_sign_in", mockGuestSignIn),
+  rest.patch("/auth/password", mockAuthPasswordsUpdate),
   rest.patch("/auth", mockAuthUpdate),
   rest.delete("/auth", mockAuthDelete),
   rest.get("/teams/select", mockTeamsSelect),

--- a/frontend/src/mocks/mockAuth.ts
+++ b/frontend/src/mocks/mockAuth.ts
@@ -135,3 +135,32 @@ export const mockAuthDelete: ResponseResolver<
     })
   );
 };
+
+export const mockAuthPasswordsUpdate: ResponseResolver<
+  MockedRequest,
+  typeof restContext
+> = (req, res, ctx) => {
+  return res(
+    ctx.status(200),
+    ctx.json({
+      success: true,
+      data: {
+        id: 1,
+        provider: "email",
+        uid: "update@example.com",
+        allow_password_change: false,
+        name: "USER_1",
+        nickname: null,
+        image: null,
+        email: "test@example.com",
+        team_id: 1,
+        created_at: "2022-06-05T10:16:09.882+09:00",
+        updated_at: "2022-06-05T10:16:09.882+09:00",
+        unfinished_tasks_count: [1, 2, 3],
+        avatar: "",
+        admin: false,
+      },
+      message: "パスワードの更新に成功しました。",
+    })
+  );
+};

--- a/frontend/src/pages/UsersEdit.tsx
+++ b/frontend/src/pages/UsersEdit.tsx
@@ -1,33 +1,20 @@
-import {
-  ChangeEvent,
-  FC,
-  FormEvent,
-  useContext,
-  useEffect,
-  useState,
-} from "react";
+import { FC, SyntheticEvent, useContext, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import Cookies from "js-cookie";
-import {
-  Button,
-  Grid,
-  IconButton,
-  TextField,
-  Tooltip,
-  Typography,
-} from "@mui/material";
-import PhotoCamera from "@mui/icons-material/PhotoCamera";
+import { Box, Button, Grid, Tab, Typography } from "@mui/material";
+import { TabContext, TabList, TabPanel } from "@mui/lab";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { axiosInstance } from "../utils/axios";
+import { User } from "../types";
 import { useFetchUser } from "../hooks/useFetchUser";
 import { AuthContext } from "../providers/AuthProvider";
-import { User, UsersEditResponse } from "../types";
 import { SnackbarContext } from "../providers/SnackbarProvider";
 import { AlertDialog } from "../components/AlertDialog";
+import { UsersEditProfile } from "./UsersEditProfile";
+import { UsersEditPassword } from "./UsersEditPassword";
 
 const UsersEdit: FC = () => {
-  const { setIsSignedIn, currentUser, setCurrentUser } =
-    useContext(AuthContext);
+  const { setIsSignedIn } = useContext(AuthContext);
   const { handleSetSnackbar } = useContext(SnackbarContext);
   const navigate = useNavigate();
   const { user: userData } = useFetchUser();
@@ -49,15 +36,11 @@ const UsersEdit: FC = () => {
     admin: false,
   });
 
-  const [image, setImage] = useState({
-    data: "",
-    filename: "",
-  });
+  const [value, setValue] = useState("1");
 
-  const [newPasswords, setNewPasswords] = useState({
-    password: "",
-    passwordConfirmation: "",
-  });
+  const handleChange = (event: SyntheticEvent, newValue: string) => {
+    setValue(newValue);
+  };
 
   const [open, setOpen] = useState(false);
 
@@ -67,76 +50,6 @@ const UsersEdit: FC = () => {
 
   const handleClose = () => {
     setOpen(false);
-  };
-
-  const handleInputChangeUsers = (
-    event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
-  ) => {
-    const { name, value } = event.target;
-    setUser({ ...user, [name]: value });
-  };
-
-  const handleInputChangePasswords = (
-    event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
-  ) => {
-    const { name, value } = event.target;
-    setNewPasswords({ ...newPasswords, [name]: value });
-  };
-
-  const handleImageSelect = (event: FormEvent) => {
-    const reader = new FileReader();
-    const { files } = event.target as HTMLInputElement;
-    if (files) {
-      reader.onload = () => {
-        setImage({
-          data: reader.result as string,
-          filename: files[0] ? files[0].name : "unknownfile",
-        });
-      };
-      reader.readAsDataURL(files[0]);
-    }
-  };
-
-  const handleUsersUpdate = () => {
-    const updateOptions: AxiosRequestConfig = {
-      url: "/auth",
-      method: "PATCH",
-      headers: {
-        "Content-Type": "application/json",
-        "access-token": Cookies.get("_access_token") || "",
-        client: Cookies.get("_client") || "",
-        uid: Cookies.get("_uid") || "",
-      },
-      data: {
-        name: user.name,
-        email: user.email,
-        avatar: image,
-      },
-    };
-
-    axiosInstance(updateOptions)
-      .then((res: AxiosResponse<UsersEditResponse>) => {
-        console.log(res);
-
-        if (res.status === 200) {
-          setCurrentUser(res.data.data);
-          handleSetSnackbar({
-            open: true,
-            type: "success",
-            message: "ユーザー情報を更新しました",
-          });
-          navigate(`/users/${currentUser?.id}`, { replace: false });
-        }
-      })
-      .catch((err) => {
-        console.log(err);
-        handleSetSnackbar({
-          open: true,
-          type: "error",
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
-          message: err.response.data.errors.full_messages.join("。"),
-        });
-      });
   };
 
   const handleUsersDelete = () => {
@@ -184,121 +97,61 @@ const UsersEdit: FC = () => {
 
   return (
     <div>
-      <Grid container direction="column" spacing={3}>
+      <Grid container direction="column" spacing={2}>
         <Grid item>
           <Typography variant="h4" component="div">
             アカウント設定
           </Typography>
         </Grid>
         <Grid item>
-          <Grid container direction="column" spacing={1}>
-            <Grid item>
-              <Grid
-                container
-                direction="row"
-                justifyContent="space-between"
-                alignItems="center"
-              >
-                <Grid item>
-                  <Typography variant="subtitle1" component="div">
-                    アイコン画像
-                  </Typography>
+          <Box sx={{ width: 400 }}>
+            <TabContext value={value}>
+              <Box sx={{ borderBottom: 1, borderColor: "divider" }}>
+                <TabList
+                  onChange={handleChange}
+                  textColor="secondary"
+                  indicatorColor="secondary"
+                >
+                  <Tab label="プロフィール" value="1" />
+                  <Tab label="パスワード再設定" value="2" />
+                  <Tab label="その他" value="3" />
+                </TabList>
+              </Box>
+              <TabPanel value="1">
+                <Grid container justifyContent="center">
+                  <Grid item>
+                    <UsersEditProfile user={user} setUser={setUser} />
+                  </Grid>
                 </Grid>
-                <Grid item>
-                  <Tooltip title="ファイル選択" placement="top" arrow>
-                    <IconButton component="label">
-                      <input
-                        hidden
-                        accept="image/*"
-                        type="file"
-                        onChange={handleImageSelect}
-                      />
-                      <PhotoCamera />
-                    </IconButton>
-                  </Tooltip>
+              </TabPanel>
+              <TabPanel value="2">
+                <Grid container justifyContent="center">
+                  <Grid item>
+                    <UsersEditPassword />
+                  </Grid>
                 </Grid>
-              </Grid>
-            </Grid>
-            <Grid item>
-              {user.avatar ? (
-                <img src={user.avatar} alt="avatar" width={300} height="auto" />
-              ) : (
-                <Typography variant="body1" component="div">
-                  未設定
-                </Typography>
-              )}
-            </Grid>
-            <Grid item>
-              {image ? (
-                <Typography variant="body1" component="div">
-                  選択中のファイル：{image.filename}
-                </Typography>
-              ) : null}
-            </Grid>
-          </Grid>
-        </Grid>
-        <Grid item>
-          <TextField
-            label="ユーザー名"
-            variant="standard"
-            sx={{ width: "30ch" }}
-            name="name"
-            value={user?.name}
-            onChange={handleInputChangeUsers}
-          />
-        </Grid>
-        <Grid item>
-          <TextField
-            label="メールアドレス"
-            variant="standard"
-            sx={{ width: "30ch" }}
-            name="email"
-            value={user?.email}
-            onChange={handleInputChangeUsers}
-          />
-        </Grid>
-        <Grid item>
-          <Button variant="contained" type="submit" onClick={handleUsersUpdate}>
-            更新する
-          </Button>
-        </Grid>
-        <Grid item>
-          <TextField
-            type="password"
-            label="新しいパスワード"
-            variant="standard"
-            sx={{ width: "30ch" }}
-            name="password"
-            value={newPasswords.password}
-            onChange={handleInputChangePasswords}
-          />
-        </Grid>
-        <Grid item>
-          <TextField
-            type="password"
-            label="新しいパスワード(確認用)"
-            variant="standard"
-            sx={{ width: "30ch" }}
-            name="passwordConfirmation"
-            value={newPasswords.passwordConfirmation}
-            onChange={handleInputChangePasswords}
-          />
-        </Grid>
-        <Grid item>
-          <Button color="secondary" variant="contained">
-            パスワード変更
-          </Button>
-        </Grid>
-        <Grid item>
-          <Button color="error" variant="outlined" onClick={handleClickOpen}>
-            アカウント削除
-          </Button>
-          <AlertDialog
-            open={open}
-            handleClose={handleClose}
-            objectName="アカウント"
-            onClick={handleUsersDelete}
-          />
+              </TabPanel>
+              <TabPanel value="3">
+                <Grid container justifyContent="center">
+                  <Grid item>
+                    <Button
+                      color="error"
+                      variant="outlined"
+                      onClick={handleClickOpen}
+                    >
+                      アカウント削除
+                    </Button>
+                    <AlertDialog
+                      open={open}
+                      handleClose={handleClose}
+                      objectName="アカウント"
+                      onClick={handleUsersDelete}
+                    />
+                  </Grid>
+                </Grid>
+              </TabPanel>
+            </TabContext>
+          </Box>
         </Grid>
       </Grid>
     </div>

--- a/frontend/src/pages/UsersEdit.tsx
+++ b/frontend/src/pages/UsersEdit.tsx
@@ -54,6 +54,11 @@ const UsersEdit: FC = () => {
     filename: "",
   });
 
+  const [newPasswords, setNewPasswords] = useState({
+    password: "",
+    passwordConfirmation: "",
+  });
+
   const [open, setOpen] = useState(false);
 
   const handleClickOpen = () => {
@@ -64,11 +69,18 @@ const UsersEdit: FC = () => {
     setOpen(false);
   };
 
-  const handleInputChange = (
+  const handleInputChangeUsers = (
     event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
   ) => {
     const { name, value } = event.target;
     setUser({ ...user, [name]: value });
+  };
+
+  const handleInputChangePasswords = (
+    event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    const { name, value } = event.target;
+    setNewPasswords({ ...newPasswords, [name]: value });
   };
 
   const handleImageSelect = (event: FormEvent) => {
@@ -232,7 +244,7 @@ const UsersEdit: FC = () => {
             sx={{ width: "30ch" }}
             name="name"
             value={user?.name}
-            onChange={handleInputChange}
+            onChange={handleInputChangeUsers}
           />
         </Grid>
         <Grid item>
@@ -242,13 +254,35 @@ const UsersEdit: FC = () => {
             sx={{ width: "30ch" }}
             name="email"
             value={user?.email}
-            onChange={handleInputChange}
+            onChange={handleInputChangeUsers}
           />
         </Grid>
         <Grid item>
           <Button variant="contained" type="submit" onClick={handleUsersUpdate}>
             更新する
           </Button>
+        </Grid>
+        <Grid item>
+          <TextField
+            type="password"
+            label="新しいパスワード"
+            variant="standard"
+            sx={{ width: "30ch" }}
+            name="password"
+            value={newPasswords.password}
+            onChange={handleInputChangePasswords}
+          />
+        </Grid>
+        <Grid item>
+          <TextField
+            type="password"
+            label="新しいパスワード(確認用)"
+            variant="standard"
+            sx={{ width: "30ch" }}
+            name="passwordConfirmation"
+            value={newPasswords.passwordConfirmation}
+            onChange={handleInputChangePasswords}
+          />
         </Grid>
         <Grid item>
           <Button color="secondary" variant="contained">

--- a/frontend/src/pages/UsersEditPassword.tsx
+++ b/frontend/src/pages/UsersEditPassword.tsx
@@ -96,7 +96,7 @@ export const UsersEditPassword = () => {
           variant="contained"
           onClick={handlePasswordUpdate}
         >
-          パスワード変更
+          更新する
         </Button>
       </Grid>
     </Grid>

--- a/frontend/src/pages/UsersEditPassword.tsx
+++ b/frontend/src/pages/UsersEditPassword.tsx
@@ -1,0 +1,48 @@
+import { ChangeEvent, useState } from "react";
+import { Button, Grid, TextField } from "@mui/material";
+
+export const UsersEditPassword = () => {
+  const [newPasswords, setNewPasswords] = useState({
+    password: "",
+    passwordConfirmation: "",
+  });
+
+  const handleInputChangePasswords = (
+    event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    const { name, value } = event.target;
+    setNewPasswords({ ...newPasswords, [name]: value });
+  };
+
+  return (
+    <Grid container direction="column" spacing={3}>
+      <Grid item>
+        <TextField
+          type="password"
+          label="新しいパスワード"
+          variant="standard"
+          sx={{ width: "30ch" }}
+          name="password"
+          value={newPasswords.password}
+          onChange={handleInputChangePasswords}
+        />
+      </Grid>
+      <Grid item>
+        <TextField
+          type="password"
+          label="新しいパスワード(確認用)"
+          variant="standard"
+          sx={{ width: "30ch" }}
+          name="passwordConfirmation"
+          value={newPasswords.passwordConfirmation}
+          onChange={handleInputChangePasswords}
+        />
+      </Grid>
+      <Grid item>
+        <Button color="secondary" variant="contained">
+          パスワード変更
+        </Button>
+      </Grid>
+    </Grid>
+  );
+};

--- a/frontend/src/pages/UsersEditPassword.tsx
+++ b/frontend/src/pages/UsersEditPassword.tsx
@@ -1,7 +1,18 @@
-import { ChangeEvent, useState } from "react";
+import { ChangeEvent, useContext, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import Cookies from "js-cookie";
 import { Button, Grid, TextField } from "@mui/material";
+import { AxiosRequestConfig, AxiosResponse } from "axios";
+import { axiosInstance } from "../utils/axios";
+import { AuthPasswordResponse } from "../types";
+import { AuthContext } from "../providers/AuthProvider";
+import { SnackbarContext } from "../providers/SnackbarProvider";
 
 export const UsersEditPassword = () => {
+  const { currentUser, setCurrentUser } = useContext(AuthContext);
+  const { handleSetSnackbar } = useContext(SnackbarContext);
+  const navigate = useNavigate();
+
   const [newPasswords, setNewPasswords] = useState({
     password: "",
     passwordConfirmation: "",
@@ -12,6 +23,47 @@ export const UsersEditPassword = () => {
   ) => {
     const { name, value } = event.target;
     setNewPasswords({ ...newPasswords, [name]: value });
+  };
+
+  const handlePasswordUpdate = () => {
+    const options: AxiosRequestConfig = {
+      url: "/auth/password",
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        "access-token": Cookies.get("_access_token") || "",
+        client: Cookies.get("_client") || "",
+        uid: Cookies.get("_uid") || "",
+      },
+      data: {
+        password: newPasswords.password,
+        password_confirmation: newPasswords.passwordConfirmation,
+      },
+    };
+
+    axiosInstance(options)
+      .then((res: AxiosResponse<AuthPasswordResponse>) => {
+        console.log(res);
+
+        if (res.status === 200) {
+          setCurrentUser(res.data.data);
+          handleSetSnackbar({
+            open: true,
+            type: "success",
+            message: "パスワードを更新しました",
+          });
+          navigate(`/users/${currentUser?.id}`, { replace: false });
+        }
+      })
+      .catch((err) => {
+        console.log(err);
+        handleSetSnackbar({
+          open: true,
+          type: "error",
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
+          message: err.response.data.errors.full_messages.join("。"),
+        });
+      });
   };
 
   return (
@@ -39,7 +91,11 @@ export const UsersEditPassword = () => {
         />
       </Grid>
       <Grid item>
-        <Button color="secondary" variant="contained">
+        <Button
+          color="secondary"
+          variant="contained"
+          onClick={handlePasswordUpdate}
+        >
           パスワード変更
         </Button>
       </Grid>

--- a/frontend/src/pages/UsersEditPassword.tsx
+++ b/frontend/src/pages/UsersEditPassword.tsx
@@ -73,6 +73,7 @@ export const UsersEditPassword = () => {
           type="password"
           label="新しいパスワード"
           variant="standard"
+          color="secondary"
           sx={{ width: "30ch" }}
           name="password"
           value={newPasswords.password}
@@ -84,6 +85,7 @@ export const UsersEditPassword = () => {
           type="password"
           label="新しいパスワード(確認用)"
           variant="standard"
+          color="secondary"
           sx={{ width: "30ch" }}
           name="passwordConfirmation"
           value={newPasswords.passwordConfirmation}

--- a/frontend/src/pages/UsersEditProfile.tsx
+++ b/frontend/src/pages/UsersEditProfile.tsx
@@ -165,6 +165,7 @@ export const UsersEditProfile = (props: Props) => {
             <TextField
               label="ユーザー名"
               variant="standard"
+              color="secondary"
               sx={{ width: "30ch" }}
               name="name"
               value={user?.name}
@@ -175,6 +176,7 @@ export const UsersEditProfile = (props: Props) => {
             <TextField
               label="メールアドレス"
               variant="standard"
+              color="secondary"
               sx={{ width: "30ch" }}
               name="email"
               value={user?.email}
@@ -184,6 +186,7 @@ export const UsersEditProfile = (props: Props) => {
           <Grid item>
             <Button
               variant="contained"
+              color="secondary"
               type="submit"
               onClick={handleUsersUpdate}
             >

--- a/frontend/src/pages/UsersEditProfile.tsx
+++ b/frontend/src/pages/UsersEditProfile.tsx
@@ -1,0 +1,197 @@
+import {
+  ChangeEvent,
+  useContext,
+  useState,
+  FormEvent,
+  Dispatch,
+  SetStateAction,
+} from "react";
+import { useNavigate } from "react-router-dom";
+import Cookies from "js-cookie";
+import { PhotoCamera } from "@mui/icons-material";
+import {
+  Avatar,
+  Button,
+  Grid,
+  IconButton,
+  TextField,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import { AxiosRequestConfig, AxiosResponse } from "axios";
+import { axiosInstance } from "../utils/axios";
+import { User, UsersEditResponse } from "../types";
+import { AuthContext } from "../providers/AuthProvider";
+import { SnackbarContext } from "../providers/SnackbarProvider";
+
+type Props = {
+  user: User;
+  setUser: Dispatch<SetStateAction<User>>;
+};
+
+export const UsersEditProfile = (props: Props) => {
+  const { user, setUser } = props;
+  const { currentUser, setCurrentUser } = useContext(AuthContext);
+  const { handleSetSnackbar } = useContext(SnackbarContext);
+  const navigate = useNavigate();
+
+  const [image, setImage] = useState({
+    data: "",
+    filename: "",
+  });
+
+  const handleInputChangeUsers = (
+    event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    const { name, value } = event.target;
+    setUser({ ...user, [name]: value });
+  };
+
+  const handleImageSelect = (event: FormEvent) => {
+    const reader = new FileReader();
+    const { files } = event.target as HTMLInputElement;
+    if (files) {
+      reader.onload = () => {
+        setImage({
+          data: reader.result as string,
+          filename: files[0] ? files[0].name : "unknownfile",
+        });
+      };
+      reader.readAsDataURL(files[0]);
+    }
+  };
+
+  const handleUsersUpdate = () => {
+    const updateOptions: AxiosRequestConfig = {
+      url: "/auth",
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        "access-token": Cookies.get("_access_token") || "",
+        client: Cookies.get("_client") || "",
+        uid: Cookies.get("_uid") || "",
+      },
+      data: {
+        name: user.name,
+        email: user.email,
+        avatar: image,
+      },
+    };
+
+    axiosInstance(updateOptions)
+      .then((res: AxiosResponse<UsersEditResponse>) => {
+        console.log(res);
+
+        if (res.status === 200) {
+          setCurrentUser(res.data.data);
+          handleSetSnackbar({
+            open: true,
+            type: "success",
+            message: "ユーザー情報を更新しました",
+          });
+          navigate(`/users/${currentUser?.id}`, { replace: false });
+        }
+      })
+      .catch((err) => {
+        console.log(err);
+        handleSetSnackbar({
+          open: true,
+          type: "error",
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
+          message: err.response.data.errors.full_messages.join("。"),
+        });
+      });
+  };
+
+  return (
+    <Grid container direction="column" spacing={3}>
+      <Grid item>
+        <Grid container direction="column" spacing={1} alignItems="flex-start">
+          <Grid item>
+            <Grid
+              container
+              direction="row"
+              justifyContent="center"
+              alignItems="center"
+            >
+              <Grid item>
+                <Typography variant="subtitle1" component="div" sx={{ mr: 1 }}>
+                  アイコン画像
+                </Typography>
+              </Grid>
+              <Grid item>
+                <Tooltip title="ファイル選択" placement="top" arrow>
+                  <IconButton component="label">
+                    <input
+                      hidden
+                      accept="image/*"
+                      type="file"
+                      onChange={handleImageSelect}
+                    />
+                    <PhotoCamera />
+                  </IconButton>
+                </Tooltip>
+              </Grid>
+            </Grid>
+          </Grid>
+          <Grid item>
+            {user.avatar ? (
+              <Avatar
+                src={user.avatar}
+                alt="avatar"
+                sx={{
+                  width: { sm: 120 },
+                  height: { sm: 120 },
+                }}
+              />
+            ) : (
+              <Typography variant="body1" component="div">
+                未設定
+              </Typography>
+            )}
+          </Grid>
+          <Grid item>
+            {image ? (
+              <Typography variant="body1" component="div">
+                {image.filename}
+              </Typography>
+            ) : null}
+          </Grid>
+        </Grid>
+      </Grid>
+      <Grid item>
+        <Grid container direction="column" spacing={3}>
+          <Grid item>
+            <TextField
+              label="ユーザー名"
+              variant="standard"
+              sx={{ width: "30ch" }}
+              name="name"
+              value={user?.name}
+              onChange={handleInputChangeUsers}
+            />
+          </Grid>
+          <Grid item>
+            <TextField
+              label="メールアドレス"
+              variant="standard"
+              sx={{ width: "30ch" }}
+              name="email"
+              value={user?.email}
+              onChange={handleInputChangeUsers}
+            />
+          </Grid>
+          <Grid item>
+            <Button
+              variant="contained"
+              type="submit"
+              onClick={handleUsersUpdate}
+            >
+              更新する
+            </Button>
+          </Grid>
+        </Grid>
+      </Grid>
+    </Grid>
+  );
+};

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -77,6 +77,12 @@ export type AuthResponse = {
   data: User;
 };
 
+export type AuthPasswordResponse = {
+  success: boolean;
+  data: User;
+  message: string;
+};
+
 export type TeamsSelectResponse = {
   teams: Team[];
 };

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1264,6 +1264,17 @@
     source-map "^0.5.7"
     stylis "4.0.13"
 
+"@emotion/cache@^11.10.3":
+  version "11.10.3"
+  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.10.3.tgz#c4f67904fad10c945fea5165c3a5a0583c164b87"
+  integrity sha512-Psmp/7ovAa8appWh3g51goxu/z3iVms7JXOreq136D8Bbn6dYraPnmL6mdM8GThEx9vwSn92Fz+mGSjBzN8UPQ==
+  dependencies:
+    "@emotion/memoize" "^0.8.0"
+    "@emotion/sheet" "^1.2.0"
+    "@emotion/utils" "^1.2.0"
+    "@emotion/weak-memoize" "^0.3.0"
+    stylis "4.0.13"
+
 "@emotion/cache@^11.9.3":
   version "11.9.3"
   resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.9.3.tgz#96638449f6929fd18062cfe04d79b29b44c0d6cb"
@@ -1280,7 +1291,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
   integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
 
-"@emotion/is-prop-valid@^1.1.0":
+"@emotion/is-prop-valid@^1.1.0", "@emotion/is-prop-valid@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-1.2.0.tgz#7f2d35c97891669f7e276eb71c83376a5dc44c83"
   integrity sha512-3aDpDprjM0AwaxGE09bOPkNxHpBd+kA6jty3RnaEXdweX1DF1U3VQpPYb0g1IStAuK7SVQ1cy+bNBBKp4W3Fjg==
@@ -1333,6 +1344,11 @@
   resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.1.1.tgz#015756e2a9a3c7c5f11d8ec22966a8dbfbfac787"
   integrity sha512-J3YPccVRMiTZxYAY0IOq3kd+hUP8idY8Kz6B/Cyo+JuXq52Ek+zbPbSQUrVQp95aJ+lsAW7DPL1P2Z+U1jGkKA==
 
+"@emotion/sheet@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.2.0.tgz#771b1987855839e214fc1741bde43089397f7be5"
+  integrity sha512-OiTkRgpxescko+M51tZsMq7Puu/KP55wMT8BgpcXVG2hqXc0Vo0mfymJ/Uj24Hp0i083ji/o0aLddh08UEjq8w==
+
 "@emotion/styled@^11.9.3":
   version "11.9.3"
   resolved "https://registry.yarnpkg.com/@emotion/styled/-/styled-11.9.3.tgz#47f0c71137fec7c57035bf3659b52fb536792340"
@@ -1359,10 +1375,20 @@
   resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-1.1.0.tgz#86b0b297f3f1a0f2bdb08eeac9a2f49afd40d0cf"
   integrity sha512-iRLa/Y4Rs5H/f2nimczYmS5kFJEbpiVvgN3XVfZ022IYhuNA1IRSHEizcof88LtCTXtl9S2Cxt32KgaXEu72JQ==
 
+"@emotion/utils@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-1.2.0.tgz#9716eaccbc6b5ded2ea5a90d65562609aab0f561"
+  integrity sha512-sn3WH53Kzpw8oQ5mgMmIzzyAaH2ZqFEbozVVBSYp538E06OSE6ytOp7pRAjNQR+Q/orwqdQYJSe2m3hCOeznkw==
+
 "@emotion/weak-memoize@^0.2.5":
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
+
+"@emotion/weak-memoize@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.3.0.tgz#ea89004119dc42db2e1dba0f97d553f7372f6fcb"
+  integrity sha512-AHPmaAx+RYfZz0eYu6Gviiagpmiyw98ySSlQvCUhVGDRtDFe4DBS0x1bSjdF3gqUDYOczB+yYvBTtEylYSdRhg==
 
 "@eslint/eslintrc@^1.3.0":
   version "1.3.0"
@@ -1865,12 +1891,39 @@
     prop-types "^15.8.1"
     react-is "^18.2.0"
 
+"@mui/base@5.0.0-alpha.95":
+  version "5.0.0-alpha.95"
+  resolved "https://registry.yarnpkg.com/@mui/base/-/base-5.0.0-alpha.95.tgz#eac88ddb6ded633a73cd3c19638241f0f9fa274f"
+  integrity sha512-fcxnDeO7rBwzP0buVdI5fn0aA7NQ/AeUV5RzIIH0kOXVVT21HB4JFf41Qhwd0PIq63PXxmc6Fs2mdlzMYuPo9g==
+  dependencies:
+    "@babel/runtime" "^7.18.9"
+    "@emotion/is-prop-valid" "^1.2.0"
+    "@mui/types" "^7.2.0"
+    "@mui/utils" "^5.10.3"
+    "@popperjs/core" "^2.11.6"
+    clsx "^1.2.1"
+    prop-types "^15.8.1"
+    react-is "^18.2.0"
+
 "@mui/icons-material@^5.10.3":
   version "5.10.3"
   resolved "https://registry.yarnpkg.com/@mui/icons-material/-/icons-material-5.10.3.tgz#33bd1d973c4727ab55d02928fc8973b7f16fff55"
   integrity sha512-o0kbUlsWCBtCE0wP33cGKbyryCh7kpm2EECYMPDmWrLhbA+HUODXIdhiTFS26szp2xXo9HY1lEx0ufeJ+tddYw==
   dependencies:
     "@babel/runtime" "^7.18.9"
+
+"@mui/lab@^5.0.0-alpha.97":
+  version "5.0.0-alpha.97"
+  resolved "https://registry.yarnpkg.com/@mui/lab/-/lab-5.0.0-alpha.97.tgz#00bc8588c6a0b706830bdfa93d2b7355eff67f77"
+  integrity sha512-0qIyXcNJg2PftzUjO5nsa9D2LEiyfA+Zg7EpJMZNtkjCTGjJmqw4cp2nJIFlZDzoFb8DsjhlFl3BWAAZqRRgTw==
+  dependencies:
+    "@babel/runtime" "^7.18.9"
+    "@mui/base" "5.0.0-alpha.95"
+    "@mui/system" "^5.10.3"
+    "@mui/utils" "^5.10.3"
+    clsx "^1.2.1"
+    prop-types "^15.8.1"
+    react-is "^18.2.0"
 
 "@mui/material@^5.9.0":
   version "5.9.1"
@@ -1889,6 +1942,15 @@
     react-is "^18.2.0"
     react-transition-group "^4.4.2"
 
+"@mui/private-theming@^5.10.3":
+  version "5.10.3"
+  resolved "https://registry.yarnpkg.com/@mui/private-theming/-/private-theming-5.10.3.tgz#7325eef3e480caaaa2d866b9057943ec4fbcb8ce"
+  integrity sha512-LCYIKlkGz2BTSng2BFzzwSJBRZbChIUri2x2Nh8ryk2B1Ho7zpvE7ex6y39LlStG2Frf92NFC/V4YQbmMAjD5A==
+  dependencies:
+    "@babel/runtime" "^7.18.9"
+    "@mui/utils" "^5.10.3"
+    prop-types "^15.8.1"
+
 "@mui/private-theming@^5.9.1":
   version "5.9.1"
   resolved "https://registry.yarnpkg.com/@mui/private-theming/-/private-theming-5.9.1.tgz#4f714ed9ebd587373dc77b3fc69e9f3e720f0190"
@@ -1898,6 +1960,16 @@
     "@mui/utils" "^5.9.1"
     prop-types "^15.8.1"
 
+"@mui/styled-engine@^5.10.3":
+  version "5.10.3"
+  resolved "https://registry.yarnpkg.com/@mui/styled-engine/-/styled-engine-5.10.3.tgz#c3e061548951568936b749a58531fb269af48948"
+  integrity sha512-9Uz7eB8xXoiDvpJ9qBxZ/2xGO8xKfA2T23dw4AsQ69SQtGatrOLAapzP2lNr0tfB9xvKucclPFhRO5aLhDFOVQ==
+  dependencies:
+    "@babel/runtime" "^7.18.9"
+    "@emotion/cache" "^11.10.3"
+    csstype "^3.1.0"
+    prop-types "^15.8.1"
+
 "@mui/styled-engine@^5.8.7":
   version "5.8.7"
   resolved "https://registry.yarnpkg.com/@mui/styled-engine/-/styled-engine-5.8.7.tgz#63d0779c07677fe76d4705a02c7ae99f89b50780"
@@ -1905,6 +1977,20 @@
   dependencies:
     "@babel/runtime" "^7.17.2"
     "@emotion/cache" "^11.9.3"
+    csstype "^3.1.0"
+    prop-types "^15.8.1"
+
+"@mui/system@^5.10.3":
+  version "5.10.3"
+  resolved "https://registry.yarnpkg.com/@mui/system/-/system-5.10.3.tgz#26f82e506af506f4fddde265c20e1100baaca03e"
+  integrity sha512-uLW/CIz3zk1jr5zH0ahOUqJIrpWP02Mv4emfrplh7Mh5JCb/oumhYaC/ALJJEjzUHKg9wwiyuM0pCwK/kSf1jQ==
+  dependencies:
+    "@babel/runtime" "^7.18.9"
+    "@mui/private-theming" "^5.10.3"
+    "@mui/styled-engine" "^5.10.3"
+    "@mui/types" "^7.2.0"
+    "@mui/utils" "^5.10.3"
+    clsx "^1.2.1"
     csstype "^3.1.0"
     prop-types "^15.8.1"
 
@@ -1926,6 +2012,22 @@
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/@mui/types/-/types-7.1.4.tgz#4185c05d6df63ec673cda15feab80440abadc764"
   integrity sha512-uveM3byMbthO+6tXZ1n2zm0W3uJCQYtwt/v5zV5I77v2v18u0ITkb8xwhsDD2i3V2Kye7SaNR6FFJ6lMuY/WqQ==
+
+"@mui/types@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@mui/types/-/types-7.2.0.tgz#91380c2d42420f51f404120f7a9270eadd6f5c23"
+  integrity sha512-lGXtFKe5lp3UxTBGqKI1l7G8sE2xBik8qCfrLHD5olwP/YU0/ReWoWT7Lp1//ri32dK39oPMrJN8TgbkCSbsNA==
+
+"@mui/utils@^5.10.3":
+  version "5.10.3"
+  resolved "https://registry.yarnpkg.com/@mui/utils/-/utils-5.10.3.tgz#ce2a96f31de2a5e717f507b5383dbabbddbc4dfc"
+  integrity sha512-4jXMDPfx6bpMVuheLaOpKTjpzw39ogAZLeaLj5+RJec3E37/hAZMYjURfblLfTWMMoGoqkY03mNsZaEwNobBow==
+  dependencies:
+    "@babel/runtime" "^7.18.9"
+    "@types/prop-types" "^15.7.5"
+    "@types/react-is" "^16.7.1 || ^17.0.0"
+    prop-types "^15.8.1"
+    react-is "^18.2.0"
 
 "@mui/utils@^5.4.1", "@mui/utils@^5.9.1":
   version "5.9.1"
@@ -2001,6 +2103,11 @@
   version "2.11.5"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.5.tgz#db5a11bf66bdab39569719555b0f76e138d7bd64"
   integrity sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==
+
+"@popperjs/core@^2.11.6":
+  version "2.11.6"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.6.tgz#cee20bd55e68a1720bdab363ecf0c821ded4cd45"
+  integrity sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==
 
 "@rollup/plugin-babel@^5.2.0":
   version "5.3.1"


### PR DESCRIPTION
### 変更内容
**backend**
- `passwords#update`のレスポンスデータに`avatar`を追加
- テストの作成

**frontend**
- `UsersEdit`ページに`Tab`を導入
- パスワード更新フォーム、ボタンの作成
- パスワード更新処理の作成
- テストの作成