### PR TITLE
feat: 分担ユーザー、コメント表示の追加 #148

### DIFF
--- a/backend/.rubocop.yml
+++ b/backend/.rubocop.yml
@@ -70,3 +70,6 @@ RSpec/ExampleLength:
 
 Metrics/AbcSize:
   Max: 25
+
+Metrics/BlockLength:
+  Max: 30

--- a/backend/app/controllers/api/v1/tasks_controller.rb
+++ b/backend/app/controllers/api/v1/tasks_controller.rb
@@ -13,8 +13,11 @@ class Api::V1::TasksController < ApplicationController
   end
 
   def show
-    children_tasks = @task.children.as_json(include: :division)
-    division = @task.division
+    children_tasks = @task.children.as_json(
+      include: [{ user: { only: :name } },
+                { division: { include: { user: { only: :name } } } }]
+    )
+    division = @task.division.as_json(include: { user: { only: :name } })
     render json: { task: @task, children_tasks:, division: }, status: :ok
   end
 

--- a/backend/app/controllers/api/v1/tasks_controller.rb
+++ b/backend/app/controllers/api/v1/tasks_controller.rb
@@ -13,7 +13,9 @@ class Api::V1::TasksController < ApplicationController
   end
 
   def show
-    render json: { task: @task }, status: :ok
+    children_tasks = @task.children.as_json(include: :division)
+    division = @task.division
+    render json: { task: @task, children_tasks:, division: }, status: :ok
   end
 
   def update

--- a/backend/config/environments/development.rb
+++ b/backend/config/environments/development.rb
@@ -1,6 +1,15 @@
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
+  config.after_initialize do
+    Bullet.enable        = true
+    Bullet.alert         = true
+    Bullet.bullet_logger = true
+    Bullet.console       = true
+    Bullet.rails_logger  = true
+    Bullet.add_footer    = true
+  end
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded any time

--- a/backend/spec/requests/api/v1/tasks_spec.rb
+++ b/backend/spec/requests/api/v1/tasks_spec.rb
@@ -31,9 +31,12 @@ RSpec.describe "Api::V1::Tasks", type: :request do
     end
 
     describe "GET /:id" do
+      let(:task) { create(:task, user:, parent_id: parent_task.id) }
       let(:another_user) { create(:user, team:) }
       let(:child_task) { create(:task, user: another_user, parent_id: task.id) }
-      let!(:division) { create(:division, user:, task: child_task) }
+      let!(:division_a) { create(:division, user:, task: child_task) }
+      let(:parent_task) { create(:task, user: another_user) }
+      let!(:division_b) { create(:division, user: another_user, task:) }
 
       before do
         get "/api/v1/tasks/#{task.id}", headers:
@@ -44,10 +47,16 @@ RSpec.describe "Api::V1::Tasks", type: :request do
         expect(json["task"]["id"]).to eq task.id
       end
 
-      it "chilren_tasks, divisionが取得出来ること" do
+      it "children_tasks, divisionが取得出来ること" do
         expect(json["children_tasks"][0]["id"]).to eq child_task.id
-        expect(json["children_tasks"][0]["division"]["id"]).to eq division.id
-        expect(json["division"]).to be_nil
+        expect(json["children_tasks"][0]["division"]["id"]).to eq division_a.id
+        expect(json["division"]["id"]).to eq division_b.id
+      end
+
+      it "children_tasks, divisionのuser nameを取得出来ること" do
+        expect(json["children_tasks"][0]["user"]["name"]).to eq another_user.name
+        expect(json["children_tasks"][0]["division"]["user"]["name"]).to eq user.name
+        expect(json["division"]["user"]["name"]).to eq another_user.name
       end
     end
 

--- a/backend/spec/requests/api/v1/tasks_spec.rb
+++ b/backend/spec/requests/api/v1/tasks_spec.rb
@@ -31,10 +31,23 @@ RSpec.describe "Api::V1::Tasks", type: :request do
     end
 
     describe "GET /:id" do
+      let(:another_user) { create(:user, team:) }
+      let(:child_task) { create(:task, user: another_user, parent_id: task.id) }
+      let!(:division) { create(:division, user:, task: child_task) }
+
+      before do
+        get "/api/v1/tasks/#{task.id}", headers:
+      end
+
       it "タスクの情報取得に成功すること" do
-        get "/api/v1/tasks/#{task.id}", headers: headers
         expect(response).to have_http_status(:ok)
-        expect(response.body).to include(task.to_json)
+        expect(json["task"]["id"]).to eq task.id
+      end
+
+      it "chilren_tasks, divisionが取得出来ること" do
+        expect(json["children_tasks"][0]["id"]).to eq child_task.id
+        expect(json["children_tasks"][0]["division"]["id"]).to eq division.id
+        expect(json["division"]).to be_nil
       end
     end
 

--- a/frontend/src/hooks/useFetchTask.ts
+++ b/frontend/src/hooks/useFetchTask.ts
@@ -2,12 +2,15 @@ import { AxiosRequestConfig, AxiosResponse } from "axios";
 import Cookies from "js-cookie";
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
-import { Task, TasksResponse } from "../types";
+import { ChildrenTask, Division, Task, TasksShowResponse } from "../types";
 import { axiosInstance } from "../utils/axios";
 
 export const useFetchTask = () => {
-  const [data, setData] = useState<Task>();
   const params = useParams<{ id: string }>();
+
+  const [task, setTask] = useState<Task>();
+  const [childrenTasks, setChildrenTasks] = useState<ChildrenTask[]>([]);
+  const [division, setDivision] = useState<Division>();
 
   const options: AxiosRequestConfig = {
     url: `/tasks/${params.id}`,
@@ -21,14 +24,16 @@ export const useFetchTask = () => {
 
   useEffect(() => {
     axiosInstance(options)
-      .then((res: AxiosResponse<TasksResponse>) => {
+      .then((res: AxiosResponse<TasksShowResponse>) => {
         console.log(res);
-        setData(res?.data.task);
+        setTask(res?.data.task);
+        setChildrenTasks(res.data.children_tasks);
+        setDivision(res.data.division);
       })
       .catch((err) => {
         console.log(err);
       });
   }, []);
 
-  return data;
+  return { task, childrenTasks, division };
 };

--- a/frontend/src/hooks/useFetchTask.ts
+++ b/frontend/src/hooks/useFetchTask.ts
@@ -2,7 +2,12 @@ import { AxiosRequestConfig, AxiosResponse } from "axios";
 import Cookies from "js-cookie";
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
-import { ChildrenTask, Division, Task, TasksShowResponse } from "../types";
+import {
+  ChildrenTask,
+  DivisionIncludeUserName,
+  Task,
+  TasksShowResponse,
+} from "../types";
 import { axiosInstance } from "../utils/axios";
 
 export const useFetchTask = () => {
@@ -10,7 +15,7 @@ export const useFetchTask = () => {
 
   const [task, setTask] = useState<Task>();
   const [childrenTasks, setChildrenTasks] = useState<ChildrenTask[]>([]);
-  const [division, setDivision] = useState<Division>();
+  const [division, setDivision] = useState<DivisionIncludeUserName>();
 
   const options: AxiosRequestConfig = {
     url: `/tasks/${params.id}`,
@@ -33,7 +38,7 @@ export const useFetchTask = () => {
       .catch((err) => {
         console.log(err);
       });
-  }, []);
+  }, [params]);
 
   return { task, childrenTasks, division };
 };

--- a/frontend/src/mocks/mockTasks.ts
+++ b/frontend/src/mocks/mockTasks.ts
@@ -8,8 +8,8 @@ export const mockTasksShow: ResponseResolver<
     ctx.status(200),
     ctx.json({
       task: {
-        id: 1,
-        title: "TASK_1",
+        id: 2,
+        title: "TASK_2",
         description: "TASKTASK",
         deadline: "2022-08-31T12:00:20.000+09:00",
         priority: "medium",
@@ -17,7 +17,40 @@ export const mockTasksShow: ResponseResolver<
         user_id: 1,
         created_at: "2022-08-26T17:02:20.690+09:00",
         updated_at: "2022-08-26T22:20:34.948+09:00",
-        parent_id: null,
+        parent_id: 1,
+      },
+      children_tasks: [
+        {
+          id: 3,
+          title: "TASK_3",
+          description: "TASKTASK",
+          deadline: "2022-08-31T12:00:20.000+09:00",
+          priority: "medium",
+          is_done: false,
+          user_id: 3,
+          created_at: "2022-08-26T17:02:20.690+09:00",
+          updated_at: "2022-08-26T22:20:34.948+09:00",
+          parent_id: 2,
+          user: { name: "USER_3" },
+          division: {
+            id: 2,
+            user_id: 4,
+            task_id: 3,
+            created_at: "2022-07-03T12:00:17.069+09:00",
+            updated_at: "2022-07-03T12:00:17.069+09:00",
+            comment: "Thank you",
+            user: { name: "USER_4" },
+          },
+        },
+      ],
+      division: {
+        id: 1,
+        user_id: 2,
+        task_id: 1,
+        created_at: "2022-07-03T12:00:17.069+09:00",
+        updated_at: "2022-07-03T12:00:17.069+09:00",
+        comment: "Thank you",
+        user: { name: "USER_2" },
       },
     })
   );

--- a/frontend/src/pages/TasksEdit.tsx
+++ b/frontend/src/pages/TasksEdit.tsx
@@ -16,7 +16,7 @@ const TasksEdit: FC = () => {
   const { handleSetSnackbar } = useContext(SnackbarContext);
   const navigate = useNavigate();
   const params = useParams<{ id: string }>();
-  const data = useFetchTask();
+  const { task: taskData } = useFetchTask();
 
   const [task, setTask] = useState<EditTask>({
     title: "",
@@ -73,12 +73,12 @@ const TasksEdit: FC = () => {
   };
 
   useEffect(() => {
-    if (data) {
-      setTask(data);
-      setDeadline(data.deadline);
-      setPriority(data.priority);
+    if (taskData) {
+      setTask(taskData);
+      setDeadline(taskData.deadline);
+      setPriority(taskData.priority);
     }
-  }, [data]);
+  }, [taskData]);
 
   return (
     <div>

--- a/frontend/src/pages/TasksShow.tsx
+++ b/frontend/src/pages/TasksShow.tsx
@@ -7,6 +7,7 @@ import {
   CardActions,
   CardContent,
   CardHeader,
+  Divider,
   Grid,
   IconButton,
   Stack,
@@ -219,6 +220,55 @@ const TasksShow: FC = () => {
                 </Button>
               )}
             </CardActions>
+          </Card>
+        </Grid>
+        <Grid item>
+          <Card sx={{ minWidth: 500, p: 2 }}>
+            <CardHeader title="分担履歴" />
+            <CardContent>
+              <Divider sx={{ mb: 2 }} />
+              {childrenTasks?.map((childTask) => (
+                <div key={childTask.id}>
+                  <Stack direction="row" alignItems="center" mb={1}>
+                    <Typography
+                      variant="subtitle1"
+                      component="div"
+                      color="text.secondary"
+                      sx={{ mr: 1 }}
+                    >
+                      作成者：
+                    </Typography>
+                    <Typography variant="body1" component="div">
+                      {childTask.division.user.name}
+                    </Typography>
+                  </Stack>
+                  <Stack direction="row" alignItems="center" mb={1}>
+                    <Typography
+                      variant="subtitle1"
+                      component="div"
+                      color="text.secondary"
+                      sx={{ mr: 1 }}
+                    >
+                      送信先：
+                    </Typography>
+                    <Typography variant="body1" component="div">
+                      {childTask.user.name}
+                    </Typography>
+                  </Stack>
+                  <Typography
+                    variant="subtitle1"
+                    component="div"
+                    color="text.secondary"
+                  >
+                    コメント：
+                  </Typography>
+                  <Typography variant="body1" component="div" sx={{ mb: 1 }}>
+                    {childTask.division.comment}
+                  </Typography>
+                  <Divider sx={{ mb: 2 }} />
+                </div>
+              ))}
+            </CardContent>
           </Card>
         </Grid>
       </Grid>

--- a/frontend/src/pages/TasksShow.tsx
+++ b/frontend/src/pages/TasksShow.tsx
@@ -33,9 +33,9 @@ const TasksShow: FC = () => {
   const params = useParams<{ id: string }>();
   const { task, childrenTasks, division } = useFetchTask();
 
-  const [open, setOpen] = useState(false);
-
   const childrenTasksCount = childrenTasks.length;
+
+  const [open, setOpen] = useState(false);
 
   const handleClickOpen = () => {
     setOpen(true);
@@ -98,24 +98,6 @@ const TasksShow: FC = () => {
               }
               subheader={
                 <div>
-                  {childrenTasksCount ? (
-                    <Stack direction="row" mt={1}>
-                      <PeopleIcon
-                        sx={{
-                          width: 18,
-                          height: 18,
-                          mr: 1,
-                        }}
-                      />
-                      <Typography
-                        color="text.secondary"
-                        variant="body2"
-                        component="div"
-                      >
-                        このタスクは分担されました (親タスク)
-                      </Typography>
-                    </Stack>
-                  ) : null}
                   {division ? (
                     <Stack direction="row" mt={1}>
                       <PeopleIcon
@@ -130,7 +112,25 @@ const TasksShow: FC = () => {
                         variant="body2"
                         component="div"
                       >
-                        このタスクは分担されました (子タスク)
+                        親タスクから分担されました
+                      </Typography>
+                    </Stack>
+                  ) : null}
+                  {childrenTasksCount ? (
+                    <Stack direction="row" mt={1}>
+                      <PeopleIcon
+                        sx={{
+                          width: 18,
+                          height: 18,
+                          mr: 1,
+                        }}
+                      />
+                      <Typography
+                        color="text.secondary"
+                        variant="body2"
+                        component="div"
+                      >
+                        子タスクへ分担されました
                       </Typography>
                     </Stack>
                   ) : null}
@@ -222,55 +222,94 @@ const TasksShow: FC = () => {
             </CardActions>
           </Card>
         </Grid>
-        <Grid item>
-          <Card sx={{ minWidth: 500, p: 2 }}>
-            <CardHeader title="分担履歴" />
-            <CardContent>
-              <Divider sx={{ mb: 2 }} />
-              {childrenTasks?.map((childTask) => (
-                <div key={childTask.id}>
-                  <Stack direction="row" alignItems="center" mb={1}>
-                    <Typography
-                      variant="subtitle1"
-                      component="div"
-                      color="text.secondary"
-                      sx={{ mr: 1 }}
-                    >
-                      作成者：
-                    </Typography>
-                    <Typography variant="body1" component="div">
-                      {childTask.division.user.name}
-                    </Typography>
-                  </Stack>
-                  <Stack direction="row" alignItems="center" mb={1}>
-                    <Typography
-                      variant="subtitle1"
-                      component="div"
-                      color="text.secondary"
-                      sx={{ mr: 1 }}
-                    >
-                      送信先：
-                    </Typography>
-                    <Typography variant="body1" component="div">
-                      {childTask.user.name}
-                    </Typography>
-                  </Stack>
+        {division ? (
+          <Grid item>
+            <Card sx={{ minWidth: 500, p: 2 }}>
+              <CardHeader title="親タスク情報" />
+              <CardContent>
+                <Divider sx={{ mb: 2 }} />
+                <Stack direction="row" alignItems="center">
                   <Typography
                     variant="subtitle1"
                     component="div"
                     color="text.secondary"
+                    sx={{ mr: 1 }}
                   >
-                    コメント：
+                    From:
                   </Typography>
-                  <Typography variant="body1" component="div" sx={{ mb: 1 }}>
-                    {childTask.division.comment}
+                  <Typography variant="body1" component="div">
+                    {division.user.name}
                   </Typography>
-                  <Divider sx={{ mb: 2 }} />
-                </div>
-              ))}
-            </CardContent>
-          </Card>
-        </Grid>
+                </Stack>
+                <Typography
+                  variant="subtitle1"
+                  component="div"
+                  color="text.secondary"
+                >
+                  コメント：
+                </Typography>
+                <Typography variant="body1" component="div">
+                  {division.comment}
+                </Typography>
+                <Link to={`/tasks/${task?.parent_id}`}>参照リンク</Link>
+              </CardContent>
+            </Card>
+          </Grid>
+        ) : null}
+        {childrenTasksCount ? (
+          <Grid item>
+            <Card sx={{ minWidth: 500, p: 2 }}>
+              <CardHeader title="子タスク情報" />
+              <CardContent>
+                <Divider sx={{ mb: 2 }} />
+                {childrenTasks?.map((childTask) => (
+                  <div key={childTask.id}>
+                    <Stack direction="row" alignItems="center">
+                      <Typography
+                        variant="subtitle1"
+                        component="div"
+                        color="text.secondary"
+                        sx={{ mr: 1 }}
+                      >
+                        From:
+                      </Typography>
+                      <Typography variant="body1" component="div">
+                        {childTask.division.user.name}
+                      </Typography>
+                    </Stack>
+                    <Stack direction="row" alignItems="center">
+                      <Typography
+                        variant="subtitle1"
+                        component="div"
+                        color="text.secondary"
+                        sx={{ mr: 1 }}
+                      >
+                        To:
+                      </Typography>
+                      <Typography variant="body1" component="div">
+                        {childTask.user.name}
+                      </Typography>
+                    </Stack>
+                    <Stack direction="row" alignItems="center">
+                      <Typography
+                        variant="subtitle1"
+                        component="div"
+                        color="text.secondary"
+                      >
+                        コメント：
+                      </Typography>
+                      <Typography variant="body1" component="div">
+                        {childTask.division.comment}
+                      </Typography>
+                    </Stack>
+                    <Link to={`/tasks/${childTask.id}`}>参照リンク</Link>
+                    <Divider sx={{ my: 2 }} />
+                  </div>
+                ))}
+              </CardContent>
+            </Card>
+          </Grid>
+        ) : null}
       </Grid>
     </div>
   );

--- a/frontend/src/pages/TasksShow.tsx
+++ b/frontend/src/pages/TasksShow.tsx
@@ -17,6 +17,7 @@ import {
 import EditIcon from "@mui/icons-material/Edit";
 import DeleteIcon from "@mui/icons-material/Delete";
 import PeopleIcon from "@mui/icons-material/People";
+import LinkIcon from "@mui/icons-material/Link";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { axiosInstance } from "../utils/axios";
 import { useFetchTask } from "../hooks/useFetchTask";
@@ -233,7 +234,7 @@ const TasksShow: FC = () => {
                     variant="subtitle1"
                     component="div"
                     color="text.secondary"
-                    sx={{ mr: 1 }}
+                    sx={{ textAlign: "end", width: 85, mr: 1 }}
                   >
                     From:
                   </Typography>
@@ -241,17 +242,34 @@ const TasksShow: FC = () => {
                     {division.user.name}
                   </Typography>
                 </Stack>
-                <Typography
-                  variant="subtitle1"
-                  component="div"
-                  color="text.secondary"
-                >
-                  コメント：
-                </Typography>
-                <Typography variant="body1" component="div">
-                  {division.comment}
-                </Typography>
-                <Link to={`/tasks/${task?.parent_id}`}>参照リンク</Link>
+                {division.comment ? (
+                  <Stack direction="row" alignItems="center">
+                    <Typography
+                      variant="subtitle1"
+                      component="div"
+                      color="text.secondary"
+                      sx={{ textAlign: "end", width: 85, mr: 1 }}
+                    >
+                      コメント：
+                    </Typography>
+                    <Typography variant="body1" component="div">
+                      {division.comment}
+                    </Typography>
+                  </Stack>
+                ) : null}
+                <Stack direction="row" alignItems="center">
+                  <Typography
+                    variant="subtitle1"
+                    component="div"
+                    color="text.secondary"
+                    sx={{ textAlign: "end", width: 85, mr: 1 }}
+                  >
+                    参照リンク:
+                  </Typography>
+                  <IconButton component={Link} to={`/tasks/${task?.parent_id}`}>
+                    <LinkIcon />
+                  </IconButton>
+                </Stack>
               </CardContent>
             </Card>
           </Grid>
@@ -269,7 +287,7 @@ const TasksShow: FC = () => {
                         variant="subtitle1"
                         component="div"
                         color="text.secondary"
-                        sx={{ mr: 1 }}
+                        sx={{ textAlign: "end", width: 85, mr: 1 }}
                       >
                         From:
                       </Typography>
@@ -282,7 +300,7 @@ const TasksShow: FC = () => {
                         variant="subtitle1"
                         component="div"
                         color="text.secondary"
-                        sx={{ mr: 1 }}
+                        sx={{ textAlign: "end", width: 85, mr: 1 }}
                       >
                         To:
                       </Typography>
@@ -290,19 +308,37 @@ const TasksShow: FC = () => {
                         {childTask.user.name}
                       </Typography>
                     </Stack>
+                    {childTask.division.comment ? (
+                      <Stack direction="row" alignItems="center">
+                        <Typography
+                          variant="subtitle1"
+                          component="div"
+                          color="text.secondary"
+                          sx={{ textAlign: "end", width: 85, mr: 1 }}
+                        >
+                          コメント:
+                        </Typography>
+                        <Typography variant="body1" component="div">
+                          {childTask.division.comment}
+                        </Typography>
+                      </Stack>
+                    ) : null}
                     <Stack direction="row" alignItems="center">
                       <Typography
                         variant="subtitle1"
                         component="div"
                         color="text.secondary"
+                        sx={{ textAlign: "end", width: 85, mr: 1 }}
                       >
-                        コメント：
+                        参照リンク:
                       </Typography>
-                      <Typography variant="body1" component="div">
-                        {childTask.division.comment}
-                      </Typography>
+                      <IconButton
+                        component={Link}
+                        to={`/tasks/${childTask.id}`}
+                      >
+                        <LinkIcon />
+                      </IconButton>
                     </Stack>
-                    <Link to={`/tasks/${childTask.id}`}>参照リンク</Link>
                     <Divider sx={{ my: 2 }} />
                   </div>
                 ))}

--- a/frontend/src/pages/TasksShow.tsx
+++ b/frontend/src/pages/TasksShow.tsx
@@ -15,6 +15,7 @@ import {
 } from "@mui/material";
 import EditIcon from "@mui/icons-material/Edit";
 import DeleteIcon from "@mui/icons-material/Delete";
+import PeopleIcon from "@mui/icons-material/People";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { axiosInstance } from "../utils/axios";
 import { useFetchTask } from "../hooks/useFetchTask";
@@ -29,9 +30,11 @@ const TasksShow: FC = () => {
   const { handleSetSnackbar } = useContext(SnackbarContext);
   const navigate = useNavigate();
   const params = useParams<{ id: string }>();
-  const task = useFetchTask();
+  const { task, childrenTasks, division } = useFetchTask();
 
   const [open, setOpen] = useState(false);
+
+  const childrenTasksCount = childrenTasks.length;
 
   const handleClickOpen = () => {
     setOpen(true);
@@ -87,7 +90,51 @@ const TasksShow: FC = () => {
         <Grid item>
           <Card sx={{ minWidth: 500, p: 2 }}>
             <CardHeader
-              title={task?.title}
+              title={
+                <Typography variant="h5" component="div">
+                  {task?.title}
+                </Typography>
+              }
+              subheader={
+                <div>
+                  {childrenTasksCount ? (
+                    <Stack direction="row" mt={1}>
+                      <PeopleIcon
+                        sx={{
+                          width: 18,
+                          height: 18,
+                          mr: 1,
+                        }}
+                      />
+                      <Typography
+                        color="text.secondary"
+                        variant="body2"
+                        component="div"
+                      >
+                        このタスクは分担されました (親タスク)
+                      </Typography>
+                    </Stack>
+                  ) : null}
+                  {division ? (
+                    <Stack direction="row" mt={1}>
+                      <PeopleIcon
+                        sx={{
+                          width: 18,
+                          height: 18,
+                          mr: 1,
+                        }}
+                      />
+                      <Typography
+                        color="text.secondary"
+                        variant="body2"
+                        component="div"
+                      >
+                        このタスクは分担されました (子タスク)
+                      </Typography>
+                    </Stack>
+                  ) : null}
+                </div>
+              }
               action={
                 task?.user_id === currentUser?.id &&
                 task?.is_done === false && (

--- a/frontend/src/tests/TasksShow.test.tsx
+++ b/frontend/src/tests/TasksShow.test.tsx
@@ -52,7 +52,12 @@ describe("TasksShow", () => {
     );
 
     // タスクのタイトルが表示されている
-    expect(await screen.findByText("TASK_1")).toBeInTheDocument();
+    expect(await screen.findByText("TASK_2")).toBeInTheDocument();
+
+    // 分担ユーザーが表示されている
+    expect(await screen.findByText("USER_2")).toBeInTheDocument();
+    expect(await screen.findByText("USER_3")).toBeInTheDocument();
+    expect(await screen.findByText("USER_4")).toBeInTheDocument();
 
     await act(() => {
       userEvent.click(screen.getByTestId("delete-button"));
@@ -74,7 +79,7 @@ describe("TasksShow", () => {
 
     // 削除したタスクは表示されていない
     await waitFor(() => {
-      expect(screen.queryByText("TASK_1")).not.toBeInTheDocument();
+      expect(screen.queryByText("TASK_2")).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/tests/UsersEdit.test.tsx
+++ b/frontend/src/tests/UsersEdit.test.tsx
@@ -90,17 +90,9 @@ describe("UsersEdit", () => {
       </MemoryRouter>
     );
 
-    // ユーザー情報が表示されている
-    expect(await screen.findByDisplayValue("USER_1")).toBeInTheDocument();
-
-    await act(() => {
+    act(() => {
       userEvent.click(screen.getByText("パスワード再設定"));
     });
-
-    const updateButton = await screen.findByRole("button", {
-      name: "更新する",
-    });
-    expect(updateButton).toBeInTheDocument();
 
     await act(() => {
       userEvent.type(screen.getByLabelText("新しいパスワード"), "newpassword");
@@ -108,7 +100,7 @@ describe("UsersEdit", () => {
         screen.getByLabelText("新しいパスワード(確認用)"),
         "newpassword"
       );
-      userEvent.click(updateButton);
+      userEvent.click(screen.getByRole("button", { name: "更新する" }));
     });
 
     // 更新するとUsersShowページへ遷移する
@@ -134,18 +126,9 @@ describe("UsersEdit", () => {
       </MemoryRouter>
     );
 
-    // ユーザー情報が表示されている
-    expect(await screen.findByDisplayValue("USER_1")).toBeInTheDocument();
+    act(() => { userEvent.click(screen.getByText("その他")) });
 
-    await act(() => {
-      userEvent.click(screen.getByText("その他"));
-    });
-
-    expect(
-      await screen.findByRole("button", { name: "アカウント削除" })
-    ).toBeInTheDocument();
-
-    await act(() => {
+    act(() => {
       userEvent.click(screen.getByRole("button", { name: "アカウント削除" }));
     });
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -36,6 +36,20 @@ export type Task = {
   parent_id: number;
 };
 
+export type ChildrenTask = {
+  id: number;
+  title: string;
+  description: string;
+  deadline: Date;
+  priority: string;
+  is_done: boolean;
+  user_id: number;
+  created_at: Date;
+  updated_at: Date;
+  parent_id: number;
+  division: Division;
+};
+
 export type Division = {
   id: number;
   user_id: number;
@@ -110,6 +124,12 @@ export type UsersEditResponse = {
 
 export type TasksResponse = {
   task: Task;
+};
+
+export type TasksShowResponse = {
+  task: Task;
+  children_tasks: ChildrenTask[];
+  division: Division | undefined;
 };
 
 export type DivisionsNewResponse = {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -47,16 +47,27 @@ export type ChildrenTask = {
   created_at: Date;
   updated_at: Date;
   parent_id: number;
-  division: Division;
+  user: { name: string };
+  division: DivisionIncludeUserName;
 };
 
 export type Division = {
   id: number;
-  user_id: number;
+  user_id: number | undefined;
   task_id: number;
   created_at: Date;
   updated_at: Date;
   comment: string;
+};
+
+export type DivisionIncludeUserName = {
+  id: number;
+  user_id: number | undefined;
+  task_id: number;
+  created_at: Date;
+  updated_at: Date;
+  comment: string;
+  user: { name: string };
 };
 
 export type NewTask = {
@@ -129,7 +140,7 @@ export type TasksResponse = {
 export type TasksShowResponse = {
   task: Task;
   children_tasks: ChildrenTask[];
-  division: Division | undefined;
+  division: DivisionIncludeUserName | undefined;
 };
 
 export type DivisionsNewResponse = {


### PR DESCRIPTION
### 変更内容
**backend**
- `tasks#show`のレスポンスデータを修正
- テストの作成

**frontend**
- レスポンスデータの型定義修正
- `TasksShow`ページに分担ステータス表示を追加
- `TasksShow`ページに親タスク、子タスク欄を追加
- 親タスク、子タスク欄にユーザー名、コメント、リンクを追加
- テストの作成