### PR TITLE
feat: タスクに進捗率属性を追加 #154

### DIFF
--- a/backend/app/controllers/api/v1/tasks_controller.rb
+++ b/backend/app/controllers/api/v1/tasks_controller.rb
@@ -50,6 +50,8 @@ class Api::V1::TasksController < ApplicationController
   end
 
   def task_params
-    params.require(:task).permit(:title, :description, :deadline, :priority, :is_done, :user_id, files: [])
+    params.require(:task).permit(
+      :title, :description, :deadline, :priority, :is_done, :rate_of_progress, :user_id, files: []
+    )
   end
 end

--- a/backend/app/controllers/api/v1/teams_controller.rb
+++ b/backend/app/controllers/api/v1/teams_controller.rb
@@ -51,7 +51,7 @@ class Api::V1::TeamsController < ApplicationController
   end
 
   def team_params
-    params.require(:team).permit(:name)
+    params.require(:team).permit(:name, :max_num_of_users)
   end
 
   def ensure_correct_user

--- a/backend/app/models/task.rb
+++ b/backend/app/models/task.rb
@@ -12,6 +12,9 @@ class Task < ApplicationRecord
   validates :deadline, presence: true
   validates :priority, inclusion: { in: Task.priorities.keys }
   validates :is_done, inclusion: { in: [true, false] }
+  validates :rate_of_progress, numericality: {
+    only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 100
+  }
 
   scope :unfinished, -> { where(is_done: false) }
   scope :finished, -> { where(is_done: true) }

--- a/backend/app/models/team.rb
+++ b/backend/app/models/team.rb
@@ -2,7 +2,9 @@ class Team < ApplicationRecord
   has_many :users, dependent: :restrict_with_error
 
   validates :name, presence: true, length: { maximum: 20 }
-  validates :max_num_of_users, numericality: { in: 1..20 }
+  validates :max_num_of_users, numericality: {
+    only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 20
+  }
 
   def admin_users
     users.where(admin: true)

--- a/backend/db/migrate/20220910060050_add_rate_of_progress_to_tasks.rb
+++ b/backend/db/migrate/20220910060050_add_rate_of_progress_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddRateOfProgressToTasks < ActiveRecord::Migration[6.1]
+  def change
+    add_column :tasks, :rate_of_progress, :integer, default: 0
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_05_133424) do
+ActiveRecord::Schema.define(version: 2022_09_10_060050) do
 
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -60,6 +60,7 @@ ActiveRecord::Schema.define(version: 2022_09_05_133424) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "parent_id"
+    t.integer "rate_of_progress", default: 0
     t.index ["parent_id"], name: "index_tasks_on_parent_id"
     t.index ["user_id"], name: "index_tasks_on_user_id"
   end

--- a/backend/spec/factories/tasks.rb
+++ b/backend/spec/factories/tasks.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
     deadline { Faker::Time.between(from: DateTime.now, to: DateTime.now + 7, format: :long) }
     priority { rand(0..2) }
     is_done { false }
+    rate_of_progress { 0 }
   end
 end

--- a/backend/spec/models/task_spec.rb
+++ b/backend/spec/models/task_spec.rb
@@ -49,6 +49,24 @@ RSpec.describe Task, type: :model do
       end
     end
 
+    it "進捗率が0より小さいとバリデーションエラーが発生すること" do
+      task = build(:task, rate_of_progress: -1, user:)
+      task.valid?
+      expect(task.errors).to be_of_kind(:rate_of_progress, :greater_than_or_equal_to)
+    end
+
+    it "進捗率が100より大きいとバリデーションエラーが発生すること" do
+      task = build(:task, rate_of_progress: 101, user:)
+      task.valid?
+      expect(task.errors).to be_of_kind(:rate_of_progress, :less_than_or_equal_to)
+    end
+
+    it "進捗率が小数だとバリデーションエラーが発生すること" do
+      task = build(:task, rate_of_progress: 50.5, user:)
+      task.valid?
+      expect(task.errors).to be_of_kind(:rate_of_progress, :not_an_integer)
+    end
+
     context "ユーザーと紐付いていない時" do
       let(:task) { build(:task) }
 

--- a/backend/spec/models/task_spec.rb
+++ b/backend/spec/models/task_spec.rb
@@ -5,48 +5,33 @@ RSpec.describe Task, type: :model do
   let(:user) { create(:user, team:) }
 
   describe "validation" do
-    context "全てのカラムを適切に入力した時" do
-      let(:task) { build(:task, user:) }
-
-      it "バリデーションエラーが発生しないこと" do
-        expect(task).to be_valid
-      end
+    it "全てのカラムを入力するとバリデーションエラーが発生しないこと" do
+      task = build(:task, user:)
+      expect(task).to be_valid
     end
 
-    context "タイトルを入力しない時" do
-      let(:task) { build(:task, title: nil, user:) }
-
-      it "バリデーションエラーが発生すること" do
-        task.valid?
-        expect(task.errors).to be_of_kind(:title, :blank)
-      end
+    it "タイトルを入力しないとバリデーションエラーが発生すること" do
+      task = build(:task, title: nil, user:)
+      task.valid?
+      expect(task.errors).to be_of_kind(:title, :blank)
     end
 
-    context "納期を入力しない時" do
-      let(:task) { build(:task, deadline: nil, user:) }
-
-      it "バリデーションエラーが発生すること" do
-        task.valid?
-        expect(task.errors).to be_of_kind(:deadline, :blank)
-      end
+    it "納期を入力しないとバリデーションエラーが発生すること" do
+      task = build(:task, deadline: nil, user:)
+      task.valid?
+      expect(task.errors).to be_of_kind(:deadline, :blank)
     end
 
-    context "優先度を入力しない時" do
-      let(:task) { build(:task, priority: nil, user:) }
-
-      it "バリデーションエラーが発生すること" do
-        task.valid?
-        expect(task.errors).to be_of_kind(:priority, :inclusion)
-      end
+    it "優先度を入力しないとバリデーションエラーが発生すること" do
+      task = build(:task, priority: nil, user:)
+      task.valid?
+      expect(task.errors).to be_of_kind(:priority, :inclusion)
     end
 
-    context "完了済みフラグを入力しない時" do
-      let(:task) { build(:task, is_done: nil, user:) }
-
-      it "バリデーションエラーが発生すること" do
-        task.valid?
-        expect(task.errors).to be_of_kind(:is_done, :inclusion)
-      end
+    it "完了済みフラグを入力しないとバリデーションエラーが発生すること" do
+      task = build(:task, is_done: nil, user:)
+      task.valid?
+      expect(task.errors).to be_of_kind(:is_done, :inclusion)
     end
 
     it "進捗率が0より小さいとバリデーションエラーが発生すること" do
@@ -67,13 +52,10 @@ RSpec.describe Task, type: :model do
       expect(task.errors).to be_of_kind(:rate_of_progress, :not_an_integer)
     end
 
-    context "ユーザーと紐付いていない時" do
-      let(:task) { build(:task) }
-
-      it "バリデーションエラーが発生すること" do
-        task.valid?
-        expect(task.errors).to be_of_kind(:user, :blank)
-      end
+    it "ユーザーと紐付いていないとバリデーションエラーが発生すること" do
+      task = build(:task)
+      task.valid?
+      expect(task.errors).to be_of_kind(:user, :blank)
     end
   end
 

--- a/backend/spec/models/team_spec.rb
+++ b/backend/spec/models/team_spec.rb
@@ -1,10 +1,9 @@
 require "rails_helper"
 
 RSpec.describe Team, type: :model do
-  context "チーム名を指定しない時" do
-    let(:team) { build(:team, name: nil) }
-
+  describe "validation" do
     it "バリデーションエラーが発生すること" do
+      team = build(:team, name: nil)
       team.valid?
       expect(team.errors).to be_of_kind(:name, :blank)
     end

--- a/backend/spec/models/team_spec.rb
+++ b/backend/spec/models/team_spec.rb
@@ -2,10 +2,28 @@ require "rails_helper"
 
 RSpec.describe Team, type: :model do
   describe "validation" do
-    it "バリデーションエラーが発生すること" do
+    it "チーム名を入力しないとバリデーションエラーが発生すること" do
       team = build(:team, name: nil)
       team.valid?
       expect(team.errors).to be_of_kind(:name, :blank)
+    end
+
+    it "上限人数が1より小さいとバリデーションエラーが発生すること" do
+      team = build(:team, max_num_of_users: 0)
+      team.valid?
+      expect(team.errors).to be_of_kind(:max_num_of_users, :greater_than_or_equal_to)
+    end
+
+    it "上限人数が20より大きいとバリデーションエラーが発生すること" do
+      team = build(:team, max_num_of_users: 21)
+      team.valid?
+      expect(team.errors).to be_of_kind(:max_num_of_users, :less_than_or_equal_to)
+    end
+
+    it "上限人数が小数だとバリデーションエラーが発生すること" do
+      team = build(:team, max_num_of_users: 10.5)
+      team.valid?
+      expect(team.errors).to be_of_kind(:max_num_of_users, :not_an_integer)
     end
   end
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,7 +35,7 @@
     "start-dev": "dotenv -e .env react-scripts start",
     "start": "dotenv -e .env.prod react-scripts start",
     "build": "dotenv -e .env.prod react-scripts build",
-    "test": "jest --silent",
+    "test": "jest --silent --runInBand",
     "eject": "react-scripts eject",
     "lint": "eslint --ext 'src/**/*.{jsx,js,tsx,ts}'",
     "format": "eslint --cache --fix --resolve-plugins-relative-to . 'src/**/*.{jsx,js,tsx,ts}' && prettier --write 'src/**/*.{jsx,js,tsx,ts}'"

--- a/frontend/src/components/models/task/PriorityTextField.tsx
+++ b/frontend/src/components/models/task/PriorityTextField.tsx
@@ -32,6 +32,7 @@ export const PriorityTextField = (props: Props) => {
         name="priority"
         value={value}
         onChange={onChange}
+        sx={{ width: "10ch" }}
       >
         {priorities.map((priority) => (
           <MenuItem key={priority.value} value={priority.value}>

--- a/frontend/src/components/models/task/TasksForm.tsx
+++ b/frontend/src/components/models/task/TasksForm.tsx
@@ -1,0 +1,82 @@
+import { ChangeEvent, MouseEvent } from "react";
+import {
+  Button,
+  FormControl,
+  Grid,
+  InputAdornment,
+  InputLabel,
+  OutlinedInput,
+  Stack,
+  TextField,
+} from "@mui/material";
+import { EditTask } from "../../../types";
+import { PriorityTextField } from "./PriorityTextField";
+import { DeadlineTextField } from "./DeadlineTextField";
+
+type Props = {
+  action: string;
+  task: EditTask;
+  onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  deadline: Date | null;
+  onChangeDeadline: (newValue: Date | null) => void;
+  onClick: (event: MouseEvent<HTMLButtonElement>) => void;
+};
+
+export const TasksForm = (props: Props) => {
+  const { action, task, onChange, deadline, onChangeDeadline, onClick } = props;
+
+  return (
+    <Grid container direction="column" spacing={4}>
+      <Grid item>
+        <TextField
+          label="タイトル"
+          variant="outlined"
+          sx={{ width: "50ch" }}
+          name="title"
+          value={task.title}
+          onChange={onChange}
+        />
+      </Grid>
+      <Grid item>
+        <TextField
+          label="詳細"
+          variant="outlined"
+          multiline
+          rows={4}
+          sx={{ width: "50ch" }}
+          name="description"
+          value={task.description}
+          onChange={onChange}
+        />
+      </Grid>
+      <Grid item>
+        <Stack direction="row" spacing={5}>
+          <PriorityTextField value={task.priority} onChange={onChange} />
+          <DeadlineTextField value={deadline} onChange={onChangeDeadline} />
+        </Stack>
+      </Grid>
+      {action === "edit" ? (
+        <Grid item>
+          <FormControl sx={{ width: "10ch" }}>
+            <InputLabel htmlFor="rate-of-progress">進捗率</InputLabel>
+            <OutlinedInput
+              id="rate-of-progress"
+              label="進捗率"
+              type="number"
+              name="rate_of_progress"
+              value={task.rate_of_progress}
+              onChange={onChange}
+              endAdornment={<InputAdornment position="end">%</InputAdornment>}
+              inputProps={{ inputMode: "numeric", pattern: "[0-9]*" }}
+            />
+          </FormControl>
+        </Grid>
+      ) : null}
+      <Grid item>
+        <Button variant="contained" type="submit" onClick={onClick}>
+          完了
+        </Button>
+      </Grid>
+    </Grid>
+  );
+};

--- a/frontend/src/components/pages/TasksEdit.tsx
+++ b/frontend/src/components/pages/TasksEdit.tsx
@@ -1,25 +1,14 @@
 import { ChangeEvent, FC, useContext, useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import Cookies from "js-cookie";
-import {
-  Button,
-  FormControl,
-  Grid,
-  InputAdornment,
-  InputLabel,
-  OutlinedInput,
-  Stack,
-  TextField,
-  Typography,
-} from "@mui/material";
+import { Grid, Typography } from "@mui/material";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { axiosInstance } from "../../utils/axios";
 import { TasksResponse, EditTask } from "../../types";
 import { AuthContext } from "../../providers/AuthProvider";
 import { useFetchTask } from "../../hooks/useFetchTask";
-import { PriorityTextField } from "../models/task/PriorityTextField";
-import { DeadlineTextField } from "../models/task/DeadlineTextField";
 import { SnackbarContext } from "../../providers/SnackbarProvider";
+import { TasksForm } from "../models/task/TasksForm";
 
 const TasksEdit: FC = () => {
   const { currentUser } = useContext(AuthContext);
@@ -31,18 +20,21 @@ const TasksEdit: FC = () => {
   const [task, setTask] = useState<EditTask>({
     title: "",
     description: "",
+    priority: "",
     rate_of_progress: 0,
     user_id: 0,
   });
-
   const [deadline, setDeadline] = useState<Date | null>(new Date());
-  const [priority, setPriority] = useState<string>("low");
 
   const handleInputChange = (
     event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
   ) => {
     const { name, value } = event.target;
     setTask({ ...task, [name]: value });
+  };
+
+  const handleDeadlineChange = (newValue: Date | null) => {
+    setDeadline(newValue);
   };
 
   const handleTasksUpdate = () => {
@@ -86,7 +78,6 @@ const TasksEdit: FC = () => {
     if (taskData) {
       setTask(taskData);
       setDeadline(taskData.deadline);
-      setPriority(taskData.priority);
     }
   }, [taskData]);
 
@@ -99,62 +90,14 @@ const TasksEdit: FC = () => {
           </Typography>
         </Grid>
         <Grid item>
-          <TextField
-            label="タイトル"
-            variant="outlined"
-            sx={{ width: "50ch" }}
-            name="title"
-            value={task.title}
+          <TasksForm
+            action="edit"
+            task={task}
             onChange={handleInputChange}
+            deadline={deadline}
+            onChangeDeadline={handleDeadlineChange}
+            onClick={handleTasksUpdate}
           />
-        </Grid>
-        <Grid item>
-          <TextField
-            label="詳細"
-            variant="outlined"
-            multiline
-            rows={4}
-            sx={{ width: "50ch" }}
-            name="description"
-            value={task.description}
-            onChange={handleInputChange}
-          />
-        </Grid>
-        <Grid item>
-          <Stack direction="row" spacing={5}>
-            <PriorityTextField
-              value={priority}
-              onChange={(event) => {
-                setPriority(event.target.value);
-              }}
-            />
-            <DeadlineTextField
-              value={deadline}
-              onChange={(newValue) => {
-                setDeadline(newValue);
-              }}
-            />
-          </Stack>
-        </Grid>
-        <Grid item>
-          <FormControl sx={{ width: "10ch" }}>
-            <InputLabel htmlFor="rate-of-progress">進捗率</InputLabel>
-            <OutlinedInput
-              id="rate-of-progress"
-              label="進捗率"
-              type="number"
-              name="rate_of_progress"
-              value={task.rate_of_progress}
-              onChange={handleInputChange}
-              endAdornment={<InputAdornment position="end">%</InputAdornment>}
-              inputProps={{ inputMode: "numeric", pattern: "[0-9]*" }}
-            />
-          </FormControl>
-        </Grid>
-        <Grid item>
-          <Button variant="contained" type="submit" onClick={handleTasksUpdate}>
-            完了
-          </Button>
         </Grid>
       </Grid>
     </div>

--- a/frontend/src/components/pages/TasksEdit.tsx
+++ b/frontend/src/components/pages/TasksEdit.tsx
@@ -1,7 +1,17 @@
 import { ChangeEvent, FC, useContext, useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import Cookies from "js-cookie";
-import { Button, Grid, TextField, Typography } from "@mui/material";
+import {
+  Button,
+  FormControl,
+  Grid,
+  InputAdornment,
+  InputLabel,
+  OutlinedInput,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { axiosInstance } from "../../utils/axios";
 import { TasksResponse, EditTask } from "../../types";
@@ -21,7 +31,7 @@ const TasksEdit: FC = () => {
   const [task, setTask] = useState<EditTask>({
     title: "",
     description: "",
-    is_done: false,
+    rate_of_progress: 0,
     user_id: 0,
   });
 
@@ -91,10 +101,10 @@ const TasksEdit: FC = () => {
         <Grid item>
           <TextField
             label="タイトル"
-            variant="standard"
-            sx={{ width: "30ch" }}
+            variant="outlined"
+            sx={{ width: "50ch" }}
             name="title"
-            value={task?.title}
+            value={task.title}
             onChange={handleInputChange}
           />
         </Grid>
@@ -104,27 +114,42 @@ const TasksEdit: FC = () => {
             variant="outlined"
             multiline
             rows={4}
-            sx={{ width: "55ch" }}
+            sx={{ width: "50ch" }}
             name="description"
-            value={task?.description}
+            value={task.description}
             onChange={handleInputChange}
           />
         </Grid>
         <Grid item>
-          <DeadlineTextField
-            value={deadline}
-            onChange={(newValue) => {
-              setDeadline(newValue);
-            }}
-          />
+          <Stack direction="row" spacing={5}>
+            <PriorityTextField
+              value={priority}
+              onChange={(event) => {
+                setPriority(event.target.value);
+              }}
+            />
+            <DeadlineTextField
+              value={deadline}
+              onChange={(newValue) => {
+                setDeadline(newValue);
+              }}
+            />
+          </Stack>
         </Grid>
         <Grid item>
-          <PriorityTextField
-            value={priority}
-            onChange={(event) => {
-              setPriority(event.target.value);
-            }}
-          />
+          <FormControl sx={{ width: "10ch" }}>
+            <InputLabel htmlFor="rate-of-progress">進捗率</InputLabel>
+            <OutlinedInput
+              id="rate-of-progress"
+              label="進捗率"
+              type="number"
+              name="rate_of_progress"
+              value={task.rate_of_progress}
+              onChange={handleInputChange}
+              endAdornment={<InputAdornment position="end">%</InputAdornment>}
+              inputProps={{ inputMode: "numeric", pattern: "[0-9]*" }}
+            />
+          </FormControl>
         </Grid>
         <Grid item>
           <Button variant="contained" type="submit" onClick={handleTasksUpdate}>

--- a/frontend/src/components/pages/TasksNew.tsx
+++ b/frontend/src/components/pages/TasksNew.tsx
@@ -1,34 +1,37 @@
 import { ChangeEvent, FC, useContext, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import Cookies from "js-cookie";
-import { Button, Grid, TextField, Typography } from "@mui/material";
+import { Grid, Typography } from "@mui/material";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { axiosInstance } from "../../utils/axios";
-import { TasksResponse, NewTask } from "../../types";
+import { TasksResponse, EditTask } from "../../types";
 import { AuthContext } from "../../providers/AuthProvider";
-import { PriorityTextField } from "../models/task/PriorityTextField";
-import { DeadlineTextField } from "../models/task/DeadlineTextField";
 import { SnackbarContext } from "../../providers/SnackbarProvider";
+import { TasksForm } from "../models/task/TasksForm";
 
 const TasksNew: FC = () => {
   const { currentUser } = useContext(AuthContext);
   const { handleSetSnackbar } = useContext(SnackbarContext);
   const navigate = useNavigate();
 
-  const [task, setTask] = useState<NewTask>({
+  const [task, setTask] = useState<EditTask>({
     title: "",
     description: "",
-    is_done: false,
+    priority: "",
+    rate_of_progress: 0,
+    user_id: 0,
   });
-
   const [deadline, setDeadline] = useState<Date | null>(new Date());
-  const [priority, setPriority] = useState<string>("low");
 
   const handleInputChange = (
     event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
   ) => {
     const { name, value } = event.target;
     setTask({ ...task, [name]: value });
+  };
+
+  const handleDeadlineChange = (newValue: Date | null) => {
+    setDeadline(newValue);
   };
 
   const handleTasksCreate = () => {
@@ -45,8 +48,7 @@ const TasksNew: FC = () => {
         title: task.title,
         description: task.description,
         deadline,
-        priority,
-        is_done: task.is_done,
+        priority: task.priority,
         user_id: currentUser?.id,
       },
     };
@@ -84,47 +86,14 @@ const TasksNew: FC = () => {
           </Typography>
         </Grid>
         <Grid item>
-          <TextField
-            label="タイトル"
-            variant="standard"
-            sx={{ width: "30ch" }}
-            name="title"
-            value={task.title}
+          <TasksForm
+            action="new"
+            task={task}
             onChange={handleInputChange}
+            deadline={deadline}
+            onChangeDeadline={handleDeadlineChange}
+            onClick={handleTasksCreate}
           />
-        </Grid>
-        <Grid item>
-          <TextField
-            label="詳細"
-            variant="outlined"
-            multiline
-            rows={4}
-            sx={{ width: "55ch" }}
-            name="description"
-            value={task.description}
-            onChange={handleInputChange}
-          />
-        </Grid>
-        <Grid item>
-          <DeadlineTextField
-            value={deadline}
-            onChange={(newValue) => {
-              setDeadline(newValue);
-            }}
-          />
-        </Grid>
-        <Grid item>
-          <PriorityTextField
-            value={priority}
-            onChange={(event) => {
-              setPriority(event.target.value);
-            }}
-          />
-        </Grid>
-        <Grid item>
-          <Button variant="contained" type="submit" onClick={handleTasksCreate}>
-            完了
-          </Button>
         </Grid>
       </Grid>
     </div>

--- a/frontend/src/components/pages/TasksShow.tsx
+++ b/frontend/src/components/pages/TasksShow.tsx
@@ -48,7 +48,14 @@ const TasksShow: FC = () => {
         client: Cookies.get("_client") || "",
         uid: Cookies.get("_uid") || "",
       },
-      data: { is_done: !task?.is_done },
+      data: !task?.is_done
+        ? {
+            is_done: !task?.is_done,
+            rate_of_progress: 100,
+          }
+        : {
+            is_done: !task?.is_done,
+          },
     };
 
     axiosInstance(options)

--- a/frontend/src/components/pages/TasksShow.tsx
+++ b/frontend/src/components/pages/TasksShow.tsx
@@ -173,6 +173,16 @@ const TasksShow: FC = () => {
                     component="div"
                     color="text.secondary"
                   >
+                    優先度
+                  </Typography>
+                  <Typography variant="body1" component="div" sx={{ mb: 2 }}>
+                    {PriorityLabel(task?.priority)}
+                  </Typography>
+                  <Typography
+                    variant="subtitle1"
+                    component="div"
+                    color="text.secondary"
+                  >
                     納期
                   </Typography>
                   <Typography variant="body1" component="div" sx={{ mb: 2 }}>
@@ -183,10 +193,10 @@ const TasksShow: FC = () => {
                     component="div"
                     color="text.secondary"
                   >
-                    優先度
+                    進捗率
                   </Typography>
                   <Typography variant="body1" component="div" sx={{ mb: 2 }}>
-                    {PriorityLabel(task?.priority)}
+                    {task?.rate_of_progress}%
                   </Typography>
                   <Typography
                     variant="subtitle1"

--- a/frontend/src/components/pages/UsersShow.tsx
+++ b/frontend/src/components/pages/UsersShow.tsx
@@ -89,6 +89,7 @@ const UsersShow: FC = () => {
       ),
     },
     { field: "deadline", headerName: "納期", width: 150 },
+    { field: "rateOfProgress", headerName: "進捗率", width: 100 },
     {
       field: "actions",
       headerName: "",
@@ -175,6 +176,7 @@ const UsersShow: FC = () => {
     description: task.description,
     priority: PriorityLabel(task.priority),
     deadline: DatetimeFormat(task.deadline),
+    rateOfProgress: `${task.rate_of_progress}%`,
     updated_at: DatetimeFormat(task.updated_at),
   }));
 

--- a/frontend/src/components/pages/UsersShow.tsx
+++ b/frontend/src/components/pages/UsersShow.tsx
@@ -6,8 +6,7 @@ import {
   useEffect,
   useCallback,
 } from "react";
-import { Link, useNavigate, useParams } from "react-router-dom";
-import Cookies from "js-cookie";
+import { Link, useParams } from "react-router-dom";
 import {
   Box,
   Button,
@@ -24,19 +23,17 @@ import { DataGrid, GridColDef, GridRowId } from "@mui/x-data-grid";
 import ConnectWithoutContactIcon from "@mui/icons-material/ConnectWithoutContact";
 import EditIcon from "@mui/icons-material/Edit";
 import DeleteIcon from "@mui/icons-material/Delete";
-import { AxiosRequestConfig, AxiosResponse } from "axios";
-import { axiosInstance } from "../../utils/axios";
 import { AuthContext } from "../../providers/AuthProvider";
 import { useFetchUser } from "../../hooks/useFetchUser";
-import { Task, TasksResponse } from "../../types";
+import { Task } from "../../types";
 import { DatetimeFormat } from "../ui/DatetimeFormat";
 import { PriorityLabel } from "../models/task/PriorityLabel";
-import { SnackbarContext } from "../../providers/SnackbarProvider";
 import { TasksDeleteIconButton } from "../models/task/TasksDeleteIconButton";
 import { AlertDialog } from "../ui/AlertDialog";
 import { GetChipProps } from "../models/task/GetChipProps";
 import { TasksNewButton } from "../models/task/TasksNewButton";
 import { IsDoneUpdateButton } from "../models/task/IsDoneUpdateButton";
+import { useHandleMultiTasks } from "../../hooks/useHandleMultiTasks";
 
 const UsersShow: FC = () => {
   const [flag, setFlag] = useState<boolean>(false);
@@ -45,9 +42,7 @@ const UsersShow: FC = () => {
     flag,
   });
   const { currentUser } = useContext(AuthContext);
-  const { handleSetSnackbar } = useContext(SnackbarContext);
   const urlParams = useParams<{ id: string }>();
-  const navigate = useNavigate();
   const [isFinished, setIsFinished] = useState<boolean>(false);
   const [tasks, setTasks] = useState<Task[]>(unfinishedTasks);
   const [tabValue, setTabValue] = useState("unfinished");
@@ -62,6 +57,15 @@ const UsersShow: FC = () => {
   const handleClose = () => {
     setOpen(false);
   };
+
+  const { handleMultiIsDoneUpdate, handleMultiTasksDelete } =
+    useHandleMultiTasks({
+      selectionModel,
+      isFinished,
+      flag,
+      setFlag,
+      handleClose,
+    });
 
   const unfinishedColumns: GridColDef[] = [
     {
@@ -200,88 +204,6 @@ const UsersShow: FC = () => {
     },
     [tasks]
   );
-
-  const handleMultiIsDoneUpdate = () => {
-    // eslint-disable-next-line array-callback-return
-    selectionModel?.map((id) => {
-      const options: AxiosRequestConfig = {
-        url: `/tasks/${id}`,
-        method: "PATCH",
-        headers: {
-          "Content-Type": "application/json",
-          "access-token": Cookies.get("_access_token") || "",
-          client: Cookies.get("_client") || "",
-          uid: Cookies.get("_uid") || "",
-        },
-        data: { is_done: !isFinished },
-      };
-
-      axiosInstance(options)
-        .then((res: AxiosResponse<TasksResponse>) => {
-          console.log(res);
-          setFlag(!flag);
-
-          if (res.status === 200) {
-            handleSetSnackbar({
-              open: true,
-              type: "success",
-              message: isFinished
-                ? "タスクを未了にしました"
-                : "タスクを完了済みにしました",
-            });
-          }
-        })
-        .catch((err) => {
-          console.log(err);
-          handleSetSnackbar({
-            open: true,
-            type: "error",
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-            message: `${err.response.data.messages.join("。")}`,
-          });
-        });
-    });
-  };
-
-  const handleMultiTasksDelete = () => {
-    // eslint-disable-next-line array-callback-return
-    selectionModel?.map((id) => {
-      const options: AxiosRequestConfig = {
-        url: `/tasks/${id}`,
-        method: "DELETE",
-        headers: {
-          "access-token": Cookies.get("_access_token") || "",
-          client: Cookies.get("_client") || "",
-          uid: Cookies.get("_uid") || "",
-        },
-      };
-
-      axiosInstance(options)
-        .then((res: AxiosResponse) => {
-          console.log(res);
-          setFlag(!flag);
-
-          if (res.status === 200) {
-            handleSetSnackbar({
-              open: true,
-              type: "success",
-              message: "タスクを削除しました",
-            });
-            handleClose();
-            navigate(`/users/${currentUser?.id}`, { replace: true });
-          }
-        })
-        .catch((err) => {
-          console.log(err);
-          handleSetSnackbar({
-            open: true,
-            type: "error",
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
-            message: err.response.data.errors,
-          });
-        });
-    });
-  };
 
   useEffect(() => {
     if (unfinishedTasks && !isFinished) {

--- a/frontend/src/hooks/useHandleMultiTasks.tsx
+++ b/frontend/src/hooks/useHandleMultiTasks.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useContext } from "react";
+import { Dispatch, SetStateAction, useCallback, useContext } from "react";
 import { useNavigate } from "react-router-dom";
 import Cookies from "js-cookie";
 import { GridRowId } from "@mui/x-data-grid";
@@ -22,7 +22,7 @@ export const useHandleMultiTasks = (props: Props) => {
   const { handleSetSnackbar } = useContext(SnackbarContext);
   const navigate = useNavigate();
 
-  const handleMultiIsDoneUpdate = () => {
+  const handleMultiIsDoneUpdate = useCallback(() => {
     // eslint-disable-next-line array-callback-return
     selectionModel?.map((id) => {
       const options: AxiosRequestConfig = {
@@ -34,7 +34,14 @@ export const useHandleMultiTasks = (props: Props) => {
           client: Cookies.get("_client") || "",
           uid: Cookies.get("_uid") || "",
         },
-        data: { is_done: !isFinished },
+        data: !isFinished
+          ? {
+              is_done: !isFinished,
+              rate_of_progress: 100,
+            }
+          : {
+              is_done: !isFinished,
+            },
       };
 
       axiosInstance(options)
@@ -62,9 +69,9 @@ export const useHandleMultiTasks = (props: Props) => {
           });
         });
     });
-  };
+  }, [selectionModel, isFinished, flag, setFlag, handleClose]);
 
-  const handleMultiTasksDelete = () => {
+  const handleMultiTasksDelete = useCallback(() => {
     // eslint-disable-next-line array-callback-return
     selectionModel?.map((id) => {
       const options: AxiosRequestConfig = {
@@ -102,7 +109,7 @@ export const useHandleMultiTasks = (props: Props) => {
           });
         });
     });
-  };
+  }, [selectionModel, isFinished, flag, setFlag, handleClose]);
 
   return { handleMultiIsDoneUpdate, handleMultiTasksDelete };
 };

--- a/frontend/src/hooks/useHandleMultiTasks.tsx
+++ b/frontend/src/hooks/useHandleMultiTasks.tsx
@@ -1,0 +1,108 @@
+import { Dispatch, SetStateAction, useContext } from "react";
+import { useNavigate } from "react-router-dom";
+import Cookies from "js-cookie";
+import { GridRowId } from "@mui/x-data-grid";
+import { AxiosRequestConfig, AxiosResponse } from "axios";
+import { axiosInstance } from "../utils/axios";
+import { AuthContext } from "../providers/AuthProvider";
+import { SnackbarContext } from "../providers/SnackbarProvider";
+import { TasksResponse } from "../types";
+
+type Props = {
+  selectionModel: GridRowId[];
+  isFinished: boolean;
+  flag: boolean;
+  setFlag: Dispatch<SetStateAction<boolean>>;
+  handleClose: () => void;
+};
+
+export const useHandleMultiTasks = (props: Props) => {
+  const { selectionModel, isFinished, flag, setFlag, handleClose } = props;
+  const { currentUser } = useContext(AuthContext);
+  const { handleSetSnackbar } = useContext(SnackbarContext);
+  const navigate = useNavigate();
+
+  const handleMultiIsDoneUpdate = () => {
+    // eslint-disable-next-line array-callback-return
+    selectionModel?.map((id) => {
+      const options: AxiosRequestConfig = {
+        url: `/tasks/${id}`,
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          "access-token": Cookies.get("_access_token") || "",
+          client: Cookies.get("_client") || "",
+          uid: Cookies.get("_uid") || "",
+        },
+        data: { is_done: !isFinished },
+      };
+
+      axiosInstance(options)
+        .then((res: AxiosResponse<TasksResponse>) => {
+          console.log(res);
+          setFlag(!flag);
+
+          if (res.status === 200) {
+            handleSetSnackbar({
+              open: true,
+              type: "success",
+              message: isFinished
+                ? "タスクを未了にしました"
+                : "タスクを完了済みにしました",
+            });
+          }
+        })
+        .catch((err) => {
+          console.log(err);
+          handleSetSnackbar({
+            open: true,
+            type: "error",
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            message: `${err.response.data.messages.join("。")}`,
+          });
+        });
+    });
+  };
+
+  const handleMultiTasksDelete = () => {
+    // eslint-disable-next-line array-callback-return
+    selectionModel?.map((id) => {
+      const options: AxiosRequestConfig = {
+        url: `/tasks/${id}`,
+        method: "DELETE",
+        headers: {
+          "access-token": Cookies.get("_access_token") || "",
+          client: Cookies.get("_client") || "",
+          uid: Cookies.get("_uid") || "",
+        },
+      };
+
+      axiosInstance(options)
+        .then((res: AxiosResponse) => {
+          console.log(res);
+          setFlag(!flag);
+
+          if (res.status === 200) {
+            handleSetSnackbar({
+              open: true,
+              type: "success",
+              message: "タスクを削除しました",
+            });
+            handleClose();
+            navigate(`/users/${currentUser?.id}`, { replace: true });
+          }
+        })
+        .catch((err) => {
+          console.log(err);
+          handleSetSnackbar({
+            open: true,
+            type: "error",
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
+            message: err.response.data.errors,
+          });
+        });
+    });
+  };
+
+  return { handleMultiIsDoneUpdate, handleMultiTasksDelete };
+};

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -30,6 +30,7 @@ export type Task = {
   deadline: Date;
   priority: string;
   is_done: boolean;
+  rate_of_progress: number;
   user_id: number;
   created_at: Date;
   updated_at: Date;
@@ -43,6 +44,7 @@ export type ChildrenTask = {
   deadline: Date;
   priority: string;
   is_done: boolean;
+  rate_of_progress: number;
   user_id: number;
   created_at: Date;
   updated_at: Date;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -72,15 +72,10 @@ export type DivisionIncludeUserName = {
   user: { name: string };
 };
 
-export type NewTask = {
-  title: string;
-  description: string;
-  is_done: boolean;
-};
-
 export type EditTask = {
   title: string;
   description: string;
+  priority: string;
   rate_of_progress: number;
   user_id: number;
 };

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -81,7 +81,7 @@ export type NewTask = {
 export type EditTask = {
   title: string;
   description: string;
-  is_done: boolean;
+  rate_of_progress: number;
   user_id: number;
 };
 


### PR DESCRIPTION
### 変更内容
**backend**
-  `Tasks`テーブルに`rate_of_progress`カラムを追加
-  `run_of_progress`にバリデーションを設定
- テストの作成

**frontend**
-  `Task`の型定義に`run_of_progress`を追加
-  `UsersShow`, `TasksShow`に進捗率を表示