### PR TITLE
fix: リソースが削除された時の挙動を修正 #172

### DIFF
--- a/backend/app/controllers/api/v1/users_controller.rb
+++ b/backend/app/controllers/api/v1/users_controller.rb
@@ -11,10 +11,10 @@ class Api::V1::UsersController < ApplicationController
     divisions = @user.divisions.includes(task: [user: :avatar_attachment])
                      .order(created_at: "DESC")
                      .map do |division|
-      division.as_json(
-        methods: [:parent_task, :parent_user, :child_task, :child_user]
-      ).merge({ parent_user_avatar: avatar_url(division.parent_user) },
-              { child_user_avatar: avatar_url(division.child_user) })
+      division.as_json(include: { user: { only: :name } },
+                       methods: [:parent_task, :parent_user, :child_task, :child_user])
+              .merge({ parent_user_avatar: avatar_url(division.parent_user) },
+                     { child_user_avatar: avatar_url(division.child_user) })
     end
 
     render json: {

--- a/backend/app/controllers/application_controller.rb
+++ b/backend/app/controllers/application_controller.rb
@@ -1,13 +1,13 @@
 class ApplicationController < ActionController::API
   include DeviseTokenAuth::Concerns::SetUserByToken
 
-  def error_messages(obj)
-    obj.errors.full_messages
+  def error_messages(resource)
+    resource.errors.full_messages
   end
 
-  def avatar_url(obj)
-    if obj.avatar.attached?
-      url_for(obj.avatar)
+  def avatar_url(user)
+    if user.avatar.attached?
+      url_for(user.avatar)
     else
       ""
     end

--- a/backend/app/controllers/application_controller.rb
+++ b/backend/app/controllers/application_controller.rb
@@ -6,7 +6,7 @@ class ApplicationController < ActionController::API
   end
 
   def avatar_url(user)
-    if user.avatar.attached?
+    if user&.avatar&.attached?
       url_for(user.avatar)
     else
       ""

--- a/backend/app/models/division.rb
+++ b/backend/app/models/division.rb
@@ -5,11 +5,15 @@ class Division < ApplicationRecord
   validates :comment, length: { maximum: 100 }
 
   def parent_task
-    task.parent
+    if task&.parent_id?
+      task.parent
+    end
   end
 
   def parent_user
-    task.parent.user
+    if task&.parent_id?
+      task.parent.user
+    end
   end
 
   def child_task
@@ -17,6 +21,6 @@ class Division < ApplicationRecord
   end
 
   def child_user
-    task.user
+    task&.user
   end
 end

--- a/backend/app/models/task.rb
+++ b/backend/app/models/task.rb
@@ -1,6 +1,6 @@
 class Task < ApplicationRecord
   belongs_to :user
-  has_one :division, dependent: :destroy
+  has_one :division, dependent: :nullify
   has_many :children, class_name: "Task", foreign_key: "parent_id", inverse_of: :parent, dependent: :nullify
   belongs_to :parent, class_name: "Task", optional: true, inverse_of: :children
   has_many_attached :files

--- a/backend/db/migrate/20220928054421_change_column_to_null_on_divisions_taskid.rb
+++ b/backend/db/migrate/20220928054421_change_column_to_null_on_divisions_taskid.rb
@@ -1,0 +1,9 @@
+class ChangeColumnToNullOnDivisionsTaskid < ActiveRecord::Migration[6.1]
+  def up
+    change_column_null :divisions, :task_id, true
+  end
+
+  def down
+    change_column_null :divisions, :task_id, false
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_10_060050) do
+ActiveRecord::Schema.define(version: 2022_09_28_054421) do
 
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -42,7 +42,7 @@ ActiveRecord::Schema.define(version: 2022_09_10_060050) do
 
   create_table "divisions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id"
-    t.bigint "task_id", null: false
+    t.bigint "task_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "comment"

--- a/frontend/src/components/models/task/IsDoneTypography.tsx
+++ b/frontend/src/components/models/task/IsDoneTypography.tsx
@@ -1,6 +1,5 @@
 import { Stack, Typography } from "@mui/material";
 import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
-import AssignmentLateIcon from "@mui/icons-material/AssignmentLate";
 
 type Props = {
   isDone: boolean;
@@ -23,7 +22,7 @@ export const IsDoneTypography = (props: Props) => {
         </Stack>
       ) : (
         <Stack direction="row" spacing={0.5}>
-          <AssignmentLateIcon color="warning" />
+          <CheckCircleOutlineIcon color="disabled" />
           <Typography variant="body1" component="div">
             未了
           </Typography>

--- a/frontend/src/components/models/user/DivisionsDataGrid.tsx
+++ b/frontend/src/components/models/user/DivisionsDataGrid.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { Link as RouterLink } from "react-router-dom";
-import { Link, Avatar, Stack } from "@mui/material";
+import { Link, Avatar, Stack, Typography } from "@mui/material";
 import { DataGrid, GridColDef } from "@mui/x-data-grid";
 import { DivisionHistory } from "../../../types";
 import { DatetimeFormat } from "../../ui/DatetimeFormat";
@@ -15,16 +15,24 @@ export const DivisionsDataGrid = (props: Props) => {
 
   const rows = divisions.map((division) => ({
     id: division.id,
-    parent_task_id: division.parent_task.id,
-    parent_task_title: division.parent_task.title,
-    parent_user_id: division.parent_user.id,
-    parent_user_name: division.parent_user.name,
+    parent_task_id: division.parent_task ? division.parent_task.id : undefined,
+    parent_task_title: division.parent_task
+      ? division.parent_task.title
+      : "削除済みタスク",
+    parent_user_id: division.parent_user ? division.parent_user.id : undefined,
     parent_user_avatar: division.parent_user_avatar,
-    child_task_id: division.child_task.id,
-    child_task_title: division.child_task.title,
-    child_user_id: division.child_user.id,
+    parent_user_name: division.parent_user
+      ? division.parent_user.name
+      : "退会済みユーザー",
+    child_task_id: division.child_task ? division.child_task.id : undefined,
+    child_task_title: division.child_task
+      ? division.child_task.title
+      : "削除済みタスク",
+    child_user_id: division.child_user ? division.child_user.id : undefined,
     child_user_avatar: division.child_user_avatar,
-    child_user_name: division.child_user.name,
+    child_user_name: division.child_user
+      ? division.child_user.name
+      : "退会済みユーザー",
     comment: division.comment,
     created_at: DatetimeFormat(division.created_at),
   }));
@@ -35,79 +43,99 @@ export const DivisionsDataGrid = (props: Props) => {
       field: "parent_user_name",
       headerName: "分担元ユーザー",
       width: 150,
-      renderCell: (params) => (
-        <Stack direction="row" spacing={1} alignItems="center">
-          <Avatar
-            src={params.row.parent_user_avatar}
-            alt="avatar"
-            component={RouterLink}
-            to={`/users/${params.row.parent_user_id}`}
-            sx={{ width: 28, height: 28 }}
-          />
-          <Link
-            color="inherit"
-            underline="hover"
-            component={RouterLink}
-            to={`/users/${params.row.parent_user_id}`}
-          >
+      renderCell: (params) =>
+        params.row.parent_user_id ? (
+          <Stack direction="row" spacing={1} alignItems="center">
+            <Avatar
+              src={params.row.parent_user_avatar}
+              alt="avatar"
+              component={RouterLink}
+              to={`/users/${params.row.parent_user_id}`}
+              sx={{ width: 28, height: 28 }}
+            />
+            <Link
+              color="inherit"
+              underline="hover"
+              component={RouterLink}
+              to={`/users/${params.row.parent_user_id}`}
+            >
+              {params.value}
+            </Link>
+          </Stack>
+        ) : (
+          <Typography variant="body2" component="div">
             {params.value}
-          </Link>
-        </Stack>
-      ),
+          </Typography>
+        ),
     },
     {
       field: "parent_task_title",
       headerName: "分担元タスク",
       width: 160,
-      renderCell: (params) => (
-        <Link
-          color="inherit"
-          underline="hover"
-          component={RouterLink}
-          to={`/tasks/${params.row.parent_task_id}`}
-        >
-          {params.value}
-        </Link>
-      ),
+      renderCell: (params) =>
+        params.row.parent_task_id ? (
+          <Link
+            color="inherit"
+            underline="hover"
+            component={RouterLink}
+            to={`/tasks/${params.row.parent_task_id}`}
+          >
+            {params.value}
+          </Link>
+        ) : (
+          <Typography variant="body2" component="div">
+            {params.value}
+          </Typography>
+        ),
     },
     {
       field: "child_user_name",
       headerName: "分担先ユーザー",
       width: 150,
-      renderCell: (params) => (
-        <Stack direction="row" spacing={1} alignItems="center">
-          <Avatar
-            src={params.row.child_user_avatar}
-            alt="avatar"
-            component={RouterLink}
-            to={`/users/${params.row.child_user_id}`}
-            sx={{ width: 28, height: 28 }}
-          />
-          <Link
-            color="inherit"
-            underline="hover"
-            component={RouterLink}
-            to={`/users/${params.row.child_user_id}`}
-          >
+      renderCell: (params) =>
+        params.row.child_user_id ? (
+          <Stack direction="row" spacing={1} alignItems="center">
+            <Avatar
+              src={params.row.child_user_avatar}
+              alt="avatar"
+              component={RouterLink}
+              to={`/users/${params.row.child_user_id}`}
+              sx={{ width: 28, height: 28 }}
+            />
+            <Link
+              color="inherit"
+              underline="hover"
+              component={RouterLink}
+              to={`/users/${params.row.child_user_id}`}
+            >
+              {params.value}
+            </Link>
+          </Stack>
+        ) : (
+          <Typography variant="body2" component="div">
             {params.value}
-          </Link>
-        </Stack>
-      ),
+          </Typography>
+        ),
     },
     {
       field: "child_task_title",
       headerName: "分担先タスク",
       width: 160,
-      renderCell: (params) => (
-        <Link
-          color="inherit"
-          underline="hover"
-          component={RouterLink}
-          to={`/tasks/${params.row.child_task_id}`}
-        >
-          {params.value}
-        </Link>
-      ),
+      renderCell: (params) =>
+        params.row.child_task_id ? (
+          <Link
+            color="inherit"
+            underline="hover"
+            component={RouterLink}
+            to={`/tasks/${params.row.child_task_id}`}
+          >
+            {params.value}
+          </Link>
+        ) : (
+          <Typography variant="body2" component="div">
+            {params.value}
+          </Typography>
+        ),
     },
     { field: "comment", headerName: "コメント", width: 150 },
   ];

--- a/frontend/src/components/models/user/TasksDataGrid.tsx
+++ b/frontend/src/components/models/user/TasksDataGrid.tsx
@@ -85,33 +85,34 @@ export const TasksDataGrid = (props: Props) => {
       field: "actions",
       headerName: "",
       width: 150,
-      renderCell: (params) =>
-        user?.id === currentUser?.id ? (
-          <Stack direction="row" spacing={1}>
-            <Tooltip title="分担する" placement="top" arrow>
-              <IconButton
-                color="secondary"
-                component={RouterLink}
-                to={`/tasks/${params.id}/divisions/new`}
-              >
-                <ConnectWithoutContactIcon />
-              </IconButton>
-            </Tooltip>
-            <Tooltip title="編集" placement="top" arrow>
-              <IconButton
-                component={RouterLink}
-                to={`/tasks/${params.id}/edit`}
-              >
-                <EditIcon />
-              </IconButton>
-            </Tooltip>
-            <TasksDeleteIconButton taskId={params.id} />
-          </Stack>
-        ) : null,
+      renderCell: (params) => (
+        <Stack direction="row" spacing={1}>
+          <Tooltip title="分担する" placement="top" arrow>
+            <IconButton
+              color="secondary"
+              component={RouterLink}
+              to={`/tasks/${params.id}/divisions/new`}
+            >
+              <ConnectWithoutContactIcon />
+            </IconButton>
+          </Tooltip>
+          {user?.id === currentUser?.id ? (
+            <>
+              <Tooltip title="編集" placement="top" arrow>
+                <IconButton
+                  component={RouterLink}
+                  to={`/tasks/${params.id}/edit`}
+                >
+                  <EditIcon />
+                </IconButton>
+              </Tooltip>
+              <TasksDeleteIconButton taskId={params.id} />
+            </>
+          ) : null}
+        </Stack>
+      ),
       sortable: false,
       disableColumnMenu: true,
-      headerAlign: "center",
-      align: "center",
     },
   ];
 
@@ -166,8 +167,6 @@ export const TasksDataGrid = (props: Props) => {
         ) : null,
       sortable: false,
       disableColumnMenu: true,
-      headerAlign: "center",
-      align: "center",
     },
   ];
 

--- a/frontend/src/components/pages/DivisionsNew.tsx
+++ b/frontend/src/components/pages/DivisionsNew.tsx
@@ -82,7 +82,7 @@ const DivisionsNew: FC = () => {
           handleSetSnackbar({
             open: true,
             type: "success",
-            message: "分担タスクを送信しました",
+            message: "分担タスクを作成しました",
           });
           navigate(`/users/${res.data.division.user_id}`, { replace: false });
         }

--- a/frontend/src/components/pages/TasksShow.tsx
+++ b/frontend/src/components/pages/TasksShow.tsx
@@ -1,5 +1,5 @@
 import { FC, useContext, useEffect, useState } from "react";
-import { Link, useParams } from "react-router-dom";
+import { Link as RouterLink, useParams } from "react-router-dom";
 import Cookies from "js-cookie";
 import {
   Accordion,
@@ -11,6 +11,7 @@ import {
   CardContent,
   CardHeader,
   IconButton,
+  Link,
   Stack,
   Tooltip,
   Typography,
@@ -191,7 +192,7 @@ const TasksShow: FC = () => {
                       <Stack direction="row" spacing={1}>
                         <Tooltip title="編集" placement="top" arrow>
                           <IconButton
-                            component={Link}
+                            component={RouterLink}
                             to={`/tasks/${task?.id}/edit`}
                           >
                             <EditIcon />
@@ -239,16 +240,18 @@ const TasksShow: FC = () => {
                 </CardContent>
                 <CardActions>
                   <Stack direction="row" spacing={2}>
-                    <IsDoneUpdateButton
-                      onClick={handleIsDoneUpdate}
-                      disabled={false}
-                      isFinished={task.is_done}
-                    />
+                    {task.user_id === currentUser?.id ? (
+                      <IsDoneUpdateButton
+                        onClick={handleIsDoneUpdate}
+                        disabled={false}
+                        isFinished={task.is_done}
+                      />
+                    ) : null}
                     {task.is_done ? null : (
                       <Button
                         variant="contained"
                         type="button"
-                        component={Link}
+                        component={RouterLink}
                         to={`/tasks/${task.id}/divisions/new`}
                         startIcon={<ConnectWithoutContactIcon />}
                       >
@@ -260,7 +263,7 @@ const TasksShow: FC = () => {
               </Card>
             </Grid2>
             <Grid2 xs={12}>
-              {division && parentTask ? (
+              {division ? (
                 <Accordion>
                   <AccordionSummary
                     expandIcon={<ExpandMoreIcon />}
@@ -269,10 +272,34 @@ const TasksShow: FC = () => {
                     親タスク情報
                   </AccordionSummary>
                   <AccordionDetails>
-                    <ParentTaskDetails
-                      division={division}
-                      parentTask={parentTask}
-                    />
+                    {parentTask ? (
+                      <ParentTaskDetails
+                        division={division}
+                        parentTask={parentTask}
+                      />
+                    ) : (
+                      <Stack direction="column" spacing={1}>
+                        <Typography variant="body1" component="div">
+                          親タスクは削除されました。
+                        </Typography>
+                        <Typography variant="body1" component="div">
+                          分担作成者：
+                          {division.user_id ? (
+                            <Link
+                              variant="body1"
+                              color="inherit"
+                              underline="hover"
+                              component={RouterLink}
+                              to={`/users/${division.user_id}`}
+                            >
+                              {division.user.name}
+                            </Link>
+                          ) : (
+                            "退会済みユーザー"
+                          )}
+                        </Typography>
+                      </Stack>
+                    )}
                   </AccordionDetails>
                 </Accordion>
               ) : null}

--- a/frontend/src/mocks/mockUsers.ts
+++ b/frontend/src/mocks/mockUsers.ts
@@ -51,6 +51,7 @@ export const mockUsersShow: ResponseResolver<
           parent_id: null,
         },
       ],
+      divisions: null,
     })
   );
 };

--- a/frontend/src/tests/DivisionsNew.test.tsx
+++ b/frontend/src/tests/DivisionsNew.test.tsx
@@ -76,7 +76,7 @@ describe("DivisionsNew", () => {
     // UsersShowページに遷移する
     expect(await screen.findByTestId("users-show-h4")).toBeInTheDocument();
     expect(
-      await screen.findByText("分担タスクを送信しました")
+      await screen.findByText("分担タスクを作成しました")
     ).toBeInTheDocument();
   }, 8000);
 });

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -93,6 +93,9 @@ export type DivisionHistory = {
   created_at: Date;
   updated_at: Date;
   comment: string;
+  user: {
+    name: string;
+  };
   parent_task: Task;
   parent_user: User;
   parent_user_avatar: string;


### PR DESCRIPTION
### 変更内容
**backend**
- `Divisions`テーブルの`task_id`を、`null`を許可するよう修正
- 各メソッドにリソース存在チェックを追加

**frontend**
- `UsersShow`の分担履歴に`"退会済みユーザー"`, `"削除済みタスク"`表示を追加
- `TasksShow`の親タスク欄にタスクが存在しない時の表示を追加