### PR TITLE
fix: チーム画面の修正 #177

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -26,6 +26,7 @@ gem "bootsnap", ">= 1.4.4", require: false
 gem "rack-cors"
 
 gem "aws-sdk-s3", require: false
+gem "counter_culture", "~> 2.0"
 gem "devise"
 gem "devise-i18n"
 gem "devise_token_auth"

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -87,6 +87,9 @@ GEM
     byebug (11.1.3)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
+    counter_culture (2.9.0)
+      activerecord (>= 4.2)
+      activesupport (>= 4.2)
     crass (1.0.6)
     devise (4.8.1)
       bcrypt (~> 3.0)
@@ -279,6 +282,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.4)
   bullet
   byebug
+  counter_culture (~> 2.0)
   devise
   devise-i18n
   devise_token_auth

--- a/backend/app/controllers/api/v1/teams_controller.rb
+++ b/backend/app/controllers/api/v1/teams_controller.rb
@@ -8,7 +8,7 @@ class Api::V1::TeamsController < ApplicationController
     teams = []
 
     Team.all.find_each do |team|
-      if team.max_num_of_users > team.users.size
+      if team.max_num_of_users > team.users_count
         teams << team
       end
     end

--- a/backend/app/controllers/api/v1/teams_controller.rb
+++ b/backend/app/controllers/api/v1/teams_controller.rb
@@ -5,7 +5,14 @@ class Api::V1::TeamsController < ApplicationController
   before_action :ensure_admin_user, only: [:update, :destroy]
 
   def select
-    teams = Team.all
+    teams = []
+
+    Team.all.find_each do |team|
+      if team.max_num_of_users > team.users.size
+        teams << team
+      end
+    end
+
     render json: { teams: }, status: :ok
   end
 

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -9,6 +9,7 @@ class User < ApplicationRecord
 
   has_one_attached :avatar
   belongs_to :team
+  counter_culture :team
   has_many :tasks, dependent: :destroy
   has_many :divisions, dependent: :nullify
 

--- a/backend/db/migrate/20221002042410_add_users_count_to_teams.rb
+++ b/backend/db/migrate/20221002042410_add_users_count_to_teams.rb
@@ -1,0 +1,9 @@
+class AddUsersCountToTeams < ActiveRecord::Migration[6.1]
+  def self.up
+    add_column :teams, :users_count, :integer, null: false, default: 0
+  end
+
+  def self.down
+    remove_column :teams, :users_count
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_28_054421) do
+ActiveRecord::Schema.define(version: 2022_10_02_042410) do
 
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -70,6 +70,7 @@ ActiveRecord::Schema.define(version: 2022_09_28_054421) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "max_num_of_users", default: 10
+    t.integer "users_count", default: 0, null: false
   end
 
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import Home from "./components/pages/Home";
 import SignUp from "./components/pages/SignUp";
 import SignIn from "./components/pages/SignIn";
 import TeamsSelect from "./components/pages/TeamsSelect";
+import TeamsNew from "./components/pages/TeamsNew";
 import TeamsShow from "./components/pages/TeamsShow";
 import TeamsEdit from "./components/pages/TeamsEdit";
 import UsersShow from "./components/pages/UsersShow";
@@ -46,6 +47,14 @@ const App: FC = () => {
                   element={
                     <PublicRoute>
                       <TeamsSelect />
+                    </PublicRoute>
+                  }
+                />
+                <Route
+                  path="/sign_up/teams/new"
+                  element={
+                    <PublicRoute>
+                      <TeamsNew />
                     </PublicRoute>
                   }
                 />

--- a/frontend/src/components/pages/DivisionsNew.tsx
+++ b/frontend/src/components/pages/DivisionsNew.tsx
@@ -4,7 +4,11 @@ import Cookies from "js-cookie";
 import {
   Button,
   Divider,
+  FormControl,
+  InputLabel,
   MenuItem,
+  OutlinedInput,
+  Select,
   Stack,
   TextField,
   Typography,
@@ -41,6 +45,17 @@ const DivisionsNew: FC = () => {
   const [comment, setComment] = useState<string>("");
   const [teamMembers, setTeamMembers] = useState<User[]>([]);
   const [teamMemberValue, setTeamMemberValue] = useState<string>("");
+
+  const ITEM_HEIGHT = 48;
+  const ITEM_PADDING_TOP = 8;
+  const MenuProps = {
+    PaperProps: {
+      style: {
+        maxHeight: ITEM_HEIGHT * 3 + ITEM_PADDING_TOP,
+        width: 150,
+      },
+    },
+  };
 
   const handleInputChange = (
     event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
@@ -149,22 +164,23 @@ const DivisionsNew: FC = () => {
       </Grid2>
       <Divider sx={{ my: 4 }} />
       <Grid2 xs={12}>
-        <TextField
-          select
-          required
-          color="secondary"
-          label="分担先ユーザー"
-          sx={{ width: "20ch" }}
-          name="user_id"
-          value={teamMemberValue}
-          onChange={(event) => setTeamMemberValue(event.target.value)}
-        >
-          {teamMembers.map((member) => (
-            <MenuItem key={member.id} value={member.id.toString()}>
-              {member.name}
-            </MenuItem>
-          ))}
-        </TextField>
+        <FormControl required sx={{ width: 200 }} color="secondary">
+          <InputLabel id="users_label">分担先ユーザー</InputLabel>
+          <Select
+            labelId="users_label"
+            name="user_id"
+            value={teamMemberValue}
+            onChange={(event) => setTeamMemberValue(event.target.value)}
+            input={<OutlinedInput label="分担先ユーザー" />}
+            MenuProps={MenuProps}
+          >
+            {teamMembers.map((member) => (
+              <MenuItem key={member.id} value={member.id.toString()}>
+                {member.name}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
       </Grid2>
       <Grid2 xs={12}>
         <TextField

--- a/frontend/src/components/pages/DivisionsNew.tsx
+++ b/frontend/src/components/pages/DivisionsNew.tsx
@@ -21,7 +21,7 @@ import {
 import { AuthContext } from "../../providers/AuthProvider";
 import { SnackbarContext } from "../../providers/SnackbarProvider";
 import { TasksForm } from "../models/task/TasksForm";
-import { BackButton } from "../ui/BackButton";
+import { BackIconButton } from "../ui/BackIconButton";
 
 const DivisionsNew: FC = () => {
   const { teamReloadFlag, setTeamReloadFlag } = useContext(AuthContext);
@@ -132,7 +132,7 @@ const DivisionsNew: FC = () => {
     <Grid2 container direction="column" rowSpacing={3} width={700}>
       <Grid2 xs={12}>
         <Stack direction="row" spacing={1} alignItems="center">
-          <BackButton />
+          <BackIconButton />
           <Typography gutterBottom variant="h4" component="div">
             タスクを分担する
           </Typography>

--- a/frontend/src/components/pages/SignIn.tsx
+++ b/frontend/src/components/pages/SignIn.tsx
@@ -1,7 +1,7 @@
 import { ChangeEvent, FC, useContext, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import Cookies from "js-cookie";
-import { Button, TextField, Typography } from "@mui/material";
+import { Button, Stack, TextField, Typography } from "@mui/material";
 import Grid2 from "@mui/material/Unstable_Grid2/Grid2";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { axiosInstance } from "../../utils/axios";
@@ -9,6 +9,7 @@ import { AuthContext } from "../../providers/AuthProvider";
 import { AuthResponse, PasswordState } from "../../types";
 import { SnackbarContext } from "../../providers/SnackbarProvider";
 import { PasswordTextfield } from "../models/user/PasswordTextfield";
+import { BackButton } from "../ui/BackButton";
 
 const SignIn: FC = () => {
   const { setIsSignedIn } = useContext(AuthContext);
@@ -93,14 +94,17 @@ const SignIn: FC = () => {
         />
       </Grid2>
       <Grid2 xs={12}>
-        <Button
-          data-testid="sign-in-button"
-          variant="contained"
-          type="submit"
-          onClick={handleSignIn}
-        >
-          ログイン
-        </Button>
+        <Stack direction="row" spacing={1}>
+          <Button
+            data-testid="sign-in-button"
+            variant="contained"
+            type="submit"
+            onClick={handleSignIn}
+          >
+            ログイン
+          </Button>
+          <BackButton />
+        </Stack>
       </Grid2>
     </Grid2>
   );

--- a/frontend/src/components/pages/SignUp.tsx
+++ b/frontend/src/components/pages/SignUp.tsx
@@ -1,7 +1,7 @@
 import { ChangeEvent, FC, useContext, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import Cookies from "js-cookie";
-import { Button, TextField, Typography } from "@mui/material";
+import { Button, Stack, TextField, Typography } from "@mui/material";
 import Grid2 from "@mui/material/Unstable_Grid2/Grid2";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { axiosInstance } from "../../utils/axios";
@@ -9,6 +9,7 @@ import { AuthResponse, PasswordState } from "../../types/index";
 import { AuthContext } from "../../providers/AuthProvider";
 import { SnackbarContext } from "../../providers/SnackbarProvider";
 import { PasswordTextfield } from "../models/user/PasswordTextfield";
+import { BackButton } from "../ui/BackButton";
 
 type State = {
   teamId: number;
@@ -137,9 +138,12 @@ const SignUp: FC = () => {
         />
       </Grid2>
       <Grid2 xs={12}>
-        <Button variant="contained" type="submit" onClick={handleSignUp}>
-          登録する
-        </Button>
+        <Stack direction="row" spacing={1}>
+          <Button variant="contained" type="submit" onClick={handleSignUp}>
+            登録する
+          </Button>
+          <BackButton />
+        </Stack>
       </Grid2>
     </Grid2>
   );

--- a/frontend/src/components/pages/TasksEdit.tsx
+++ b/frontend/src/components/pages/TasksEdit.tsx
@@ -10,7 +10,7 @@ import { AuthContext } from "../../providers/AuthProvider";
 import { useFetchTask } from "../../hooks/useFetchTask";
 import { SnackbarContext } from "../../providers/SnackbarProvider";
 import { TasksForm } from "../models/task/TasksForm";
-import { BackButton } from "../ui/BackButton";
+import { BackIconButton } from "../ui/BackIconButton";
 
 const TasksEdit: FC = () => {
   const { currentUser } = useContext(AuthContext);
@@ -90,7 +90,7 @@ const TasksEdit: FC = () => {
     <Grid2 container direction="column" rowSpacing={3} width={700}>
       <Grid2 xs={12}>
         <Stack direction="row" spacing={1} alignItems="center">
-          <BackButton />
+          <BackIconButton />
           <Typography gutterBottom variant="h4" component="div">
             タスクを編集する
           </Typography>

--- a/frontend/src/components/pages/TasksNew.tsx
+++ b/frontend/src/components/pages/TasksNew.tsx
@@ -9,7 +9,7 @@ import { TasksResponse, EditTask } from "../../types";
 import { AuthContext } from "../../providers/AuthProvider";
 import { SnackbarContext } from "../../providers/SnackbarProvider";
 import { TasksForm } from "../models/task/TasksForm";
-import { BackButton } from "../ui/BackButton";
+import { BackIconButton } from "../ui/BackIconButton";
 
 const TasksNew: FC = () => {
   const { currentUser, teamReloadFlag, setTeamReloadFlag } =
@@ -82,7 +82,7 @@ const TasksNew: FC = () => {
     <Grid2 container direction="column" rowSpacing={3} width={700}>
       <Grid2 xs={12}>
         <Stack direction="row" spacing={1} alignItems="center">
-          <BackButton />
+          <BackIconButton />
           <Typography gutterBottom variant="h4" component="div">
             タスクを作成する
           </Typography>

--- a/frontend/src/components/pages/TasksShow.tsx
+++ b/frontend/src/components/pages/TasksShow.tsx
@@ -38,7 +38,7 @@ import { TaskContentTypography } from "../models/task/TaskContentTypography";
 import { PriorityStack } from "../models/task/PriorityStack";
 import { DeadlineTypography } from "../models/task/DeadlineTypography";
 import { IsDoneTypography } from "../models/task/IsDoneTypography";
-import { BackButton } from "../ui/BackButton";
+import { BackIconButton } from "../ui/BackIconButton";
 
 const TasksShow: FC = () => {
   const { currentUser, teamReloadFlag, setTeamReloadFlag } =
@@ -119,7 +119,7 @@ const TasksShow: FC = () => {
           >
             <Grid2 xs={12}>
               <Stack direction="row" spacing={1} alignItems="center">
-                <BackButton />
+                <BackIconButton />
                 <UserNameHeader user={user} />
               </Stack>
             </Grid2>

--- a/frontend/src/components/pages/TeamsEdit.tsx
+++ b/frontend/src/components/pages/TeamsEdit.tsx
@@ -20,7 +20,7 @@ import { useFetchTeam } from "../../hooks/useFetchTeam";
 import { EditTeam, TeamsResponse } from "../../types";
 import { AuthContext } from "../../providers/AuthProvider";
 import { SnackbarContext } from "../../providers/SnackbarProvider";
-import { BackButton } from "../ui/BackButton";
+import { BackIconButton } from "../ui/BackIconButton";
 
 const TeamsEdit: FC = () => {
   const { currentUser, teamReloadFlag, setTeamReloadFlag } =
@@ -107,7 +107,7 @@ const TeamsEdit: FC = () => {
     <Grid2 container direction="column" rowSpacing={4}>
       <Grid2 xs={12}>
         <Stack direction="row" spacing={1} alignItems="center">
-          <BackButton />
+          <BackIconButton />
           <Typography variant="h4" component="div">
             チーム設定
           </Typography>

--- a/frontend/src/components/pages/TeamsEdit.tsx
+++ b/frontend/src/components/pages/TeamsEdit.tsx
@@ -133,7 +133,6 @@ const TeamsEdit: FC = () => {
             <InputLabel id="max_num_of_users_label">上限人数</InputLabel>
             <Select
               labelId="max_num_of_users_label"
-              id="max_num_of_users"
               name="max_num_of_users"
               value={team.max_num_of_users}
               onChange={handleInputSelectChange}

--- a/frontend/src/components/pages/TeamsNew.tsx
+++ b/frontend/src/components/pages/TeamsNew.tsx
@@ -1,11 +1,12 @@
 import { FC, useContext, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { Button, TextField, Typography } from "@mui/material";
+import { Button, Stack, TextField, Typography } from "@mui/material";
 import Grid2 from "@mui/material/Unstable_Grid2/Grid2";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { axiosInstance } from "../../utils/axios";
 import { TeamsResponse } from "../../types";
 import { SnackbarContext } from "../../providers/SnackbarProvider";
+import { BackButton } from "../ui/BackButton";
 
 const TeamsNew: FC = () => {
   const { handleSetSnackbar } = useContext(SnackbarContext);
@@ -73,9 +74,12 @@ const TeamsNew: FC = () => {
         />
       </Grid2>
       <Grid2 xs={12}>
-        <Button type="submit" variant="contained" onClick={handleTeamsCreate}>
-          作成
-        </Button>
+        <Stack direction="row" spacing={1}>
+          <Button type="submit" variant="contained" onClick={handleTeamsCreate}>
+            作成
+          </Button>
+          <BackButton />
+        </Stack>
       </Grid2>
     </Grid2>
   );

--- a/frontend/src/components/pages/TeamsNew.tsx
+++ b/frontend/src/components/pages/TeamsNew.tsx
@@ -1,0 +1,84 @@
+import { FC, useContext, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Button, TextField, Typography } from "@mui/material";
+import Grid2 from "@mui/material/Unstable_Grid2/Grid2";
+import { AxiosRequestConfig, AxiosResponse } from "axios";
+import { axiosInstance } from "../../utils/axios";
+import { TeamsResponse } from "../../types";
+import { SnackbarContext } from "../../providers/SnackbarProvider";
+
+const TeamsNew: FC = () => {
+  const { handleSetSnackbar } = useContext(SnackbarContext);
+  const navigate = useNavigate();
+  const [newTeamName, setNewTeamName] = useState<string>("");
+
+  const handleTeamsCreate = () => {
+    const teamsCreateOptions: AxiosRequestConfig = {
+      url: "/teams",
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      data: { name: newTeamName },
+    };
+
+    axiosInstance(teamsCreateOptions)
+      .then((res: AxiosResponse<TeamsResponse>) => {
+        console.log(res);
+        handleSetSnackbar({
+          open: true,
+          type: "success",
+          message: "チームを作成しました",
+        });
+        navigate("/sign_up", {
+          state: {
+            teamId: res.data.team.id,
+            teamName: res.data.team.name,
+            isAdmin: true,
+          },
+        });
+      })
+      .catch((err) => {
+        console.log(err);
+        handleSetSnackbar({
+          open: true,
+          type: "error",
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+          message: `${err.response.data.messages.join("。")}`,
+        });
+      });
+  };
+
+  return (
+    <Grid2 container direction="column" rowSpacing={3}>
+      <Grid2 xs={12}>
+        <Typography variant="h4" component="div" gutterBottom>
+          新規チーム作成
+        </Typography>
+        <Typography variant="body1" component="div">
+          新しいチームの管理者としてユーザー登録します。
+        </Typography>
+      </Grid2>
+      <Grid2 xs={12}>
+        <TextField
+          required
+          type="text"
+          inputProps={{ maxLength: 20 }}
+          label="新規チーム名"
+          color="secondary"
+          helperText="20文字以内"
+          value={newTeamName}
+          onChange={(event) => setNewTeamName(event.target.value)}
+          sx={{ width: "30ch" }}
+        />
+      </Grid2>
+      <Grid2 xs={12}>
+        <Button type="submit" variant="contained" onClick={handleTeamsCreate}>
+          作成
+        </Button>
+      </Grid2>
+    </Grid2>
+  );
+};
+
+export default TeamsNew;

--- a/frontend/src/components/pages/TeamsSelect.tsx
+++ b/frontend/src/components/pages/TeamsSelect.tsx
@@ -1,10 +1,11 @@
 import { ChangeEvent, FC, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
-import { Button, MenuItem, TextField, Typography } from "@mui/material";
+import { Button, MenuItem, Stack, TextField, Typography } from "@mui/material";
 import Grid2 from "@mui/material/Unstable_Grid2/Grid2";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { axiosInstance } from "../../utils/axios";
 import { Team, TeamsSelectResponse } from "../../types";
+import { BackButton } from "../ui/BackButton";
 
 const TeamsSelect: FC = () => {
   const [teams, setTeams] = useState<Team[]>([]);
@@ -72,15 +73,18 @@ const TeamsSelect: FC = () => {
         </TextField>
       </Grid2>
       <Grid2 xs={12}>
-        <Button
-          variant="contained"
-          component={Link}
-          to="/sign_up"
-          key={teamId}
-          state={{ teamId, teamName, isAdmin: false }}
-        >
-          次へ
-        </Button>
+        <Stack direction="row" spacing={1}>
+          <Button
+            variant="contained"
+            component={Link}
+            to="/sign_up"
+            key={teamId}
+            state={{ teamId, teamName, isAdmin: false }}
+          >
+            次へ
+          </Button>
+          <BackButton />
+        </Stack>
       </Grid2>
       <Grid2 xs={12}>
         <Typography variant="body1" component="div">

--- a/frontend/src/components/pages/TeamsSelect.tsx
+++ b/frontend/src/components/pages/TeamsSelect.tsx
@@ -1,20 +1,15 @@
-import { ChangeEvent, FC, useContext, useEffect, useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { ChangeEvent, FC, useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import { Button, MenuItem, TextField, Typography } from "@mui/material";
 import Grid2 from "@mui/material/Unstable_Grid2/Grid2";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { axiosInstance } from "../../utils/axios";
-import { Team, TeamsResponse, TeamsSelectResponse } from "../../types";
-import { SnackbarContext } from "../../providers/SnackbarProvider";
+import { Team, TeamsSelectResponse } from "../../types";
 
 const TeamsSelect: FC = () => {
-  const { handleSetSnackbar } = useContext(SnackbarContext);
-  const navigate = useNavigate();
-
   const [teams, setTeams] = useState<Team[]>([]);
   const [teamId, setTeamId] = useState<string>("");
   const [teamName, setTeamName] = useState<string>("");
-  const [newTeamName, setNewTeamName] = useState<string>("");
 
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     const { value } = event.target;
@@ -29,43 +24,6 @@ const TeamsSelect: FC = () => {
     if (selectTeam) {
       setTeamName(selectTeam.name);
     }
-  };
-
-  const handleTeamsCreate = () => {
-    const teamsCreateOptions: AxiosRequestConfig = {
-      url: "/teams",
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      data: { name: newTeamName },
-    };
-
-    axiosInstance(teamsCreateOptions)
-      .then((res: AxiosResponse<TeamsResponse>) => {
-        console.log(res);
-        handleSetSnackbar({
-          open: true,
-          type: "success",
-          message: "チームを作成しました",
-        });
-        navigate("/sign_up", {
-          state: {
-            teamId: res.data.team.id,
-            teamName: res.data.team.name,
-            isAdmin: true,
-          },
-        });
-      })
-      .catch((err) => {
-        console.log(err);
-        handleSetSnackbar({
-          open: true,
-          type: "error",
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-          message: `${err.response.data.messages.join("。")}`,
-        });
-      });
   };
 
   const options: AxiosRequestConfig = {
@@ -90,7 +48,7 @@ const TeamsSelect: FC = () => {
         <Typography variant="h4" component="div" gutterBottom>
           所属チームの選択
         </Typography>
-        <Typography variant="subtitle1" component="div">
+        <Typography variant="body1" component="div">
           選択したチームでユーザー登録します。
         </Typography>
       </Grid2>
@@ -114,46 +72,29 @@ const TeamsSelect: FC = () => {
         </TextField>
       </Grid2>
       <Grid2 xs={12}>
-        <Button variant="contained" type="button">
-          <Link
-            style={{ textDecoration: "none", color: "black" }}
-            to="/sign_up"
-            key={teamId}
-            state={{ teamId, teamName, isAdmin: false }}
-          >
-            次へ
-          </Link>
+        <Button
+          variant="contained"
+          component={Link}
+          to="/sign_up"
+          key={teamId}
+          state={{ teamId, teamName, isAdmin: false }}
+        >
+          次へ
         </Button>
       </Grid2>
       <Grid2 xs={12}>
-        <Typography variant="subtitle1" component="div" sx={{ my: 2, ml: 13 }}>
+        <Typography variant="body1" component="div">
           または
         </Typography>
       </Grid2>
       <Grid2 xs={12}>
-        <Typography variant="h4" component="div" gutterBottom>
-          新規チーム作成
-        </Typography>
-        <Typography variant="subtitle1" component="div">
-          新しいチームの管理者としてユーザー登録します。
-        </Typography>
-      </Grid2>
-      <Grid2 xs={12}>
-        <TextField
-          required
-          type="text"
-          inputProps={{ maxLength: 20 }}
-          label="新規チーム名"
+        <Button
+          variant="contained"
           color="secondary"
-          helperText="20文字以内"
-          value={newTeamName}
-          onChange={(event) => setNewTeamName(event.target.value)}
-          sx={{ width: "30ch" }}
-        />
-      </Grid2>
-      <Grid2 xs={12}>
-        <Button type="submit" variant="contained" onClick={handleTeamsCreate}>
-          作成
+          component={Link}
+          to="/sign_up/teams/new"
+        >
+          新規チーム作成
         </Button>
       </Grid2>
     </Grid2>

--- a/frontend/src/components/pages/TeamsSelect.tsx
+++ b/frontend/src/components/pages/TeamsSelect.tsx
@@ -1,6 +1,16 @@
-import { ChangeEvent, FC, useEffect, useState } from "react";
+import { FC, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
-import { Button, MenuItem, Stack, TextField, Typography } from "@mui/material";
+import {
+  Button,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  OutlinedInput,
+  Select,
+  SelectChangeEvent,
+  Stack,
+  Typography,
+} from "@mui/material";
 import Grid2 from "@mui/material/Unstable_Grid2/Grid2";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { axiosInstance } from "../../utils/axios";
@@ -9,17 +19,25 @@ import { BackButton } from "../ui/BackButton";
 
 const TeamsSelect: FC = () => {
   const [teams, setTeams] = useState<Team[]>([]);
-  const [teamId, setTeamId] = useState<string>("");
-  const [teamName, setTeamName] = useState<string>("");
+  const [teamId, setTeamId] = useState<string | number>("");
+  const [teamName, setTeamName] = useState("");
 
-  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+  const ITEM_HEIGHT = 48;
+  const ITEM_PADDING_TOP = 8;
+  const MenuProps = {
+    PaperProps: {
+      style: {
+        maxHeight: ITEM_HEIGHT * 4 + ITEM_PADDING_TOP,
+        width: 250,
+      },
+    },
+  };
+
+  const handleSelectChange = (event: SelectChangeEvent<string | number>) => {
     const { value } = event.target;
     setTeamId(value);
 
-    const teamIdNumber = Number(value);
-    const selectTeam: Team | undefined = teams.find(
-      (v) => v.id === teamIdNumber
-    );
+    const selectTeam: Team | undefined = teams.find((v) => v.id === value);
     console.log(selectTeam);
 
     if (selectTeam) {
@@ -54,23 +72,22 @@ const TeamsSelect: FC = () => {
         </Typography>
       </Grid2>
       <Grid2 xs={12}>
-        <TextField
-          select
-          required
-          label="チーム"
-          color="secondary"
-          sx={{ width: "30ch" }}
-          name="id"
-          value={teamId}
-          defaultValue=""
-          onChange={handleChange}
-        >
-          {teams?.map((menu) => (
-            <MenuItem key={menu.id} value={menu.id}>
-              {menu.name}
-            </MenuItem>
-          ))}
-        </TextField>
+        <FormControl required sx={{ width: 300 }} color="secondary">
+          <InputLabel id="team_label">チーム</InputLabel>
+          <Select
+            labelId="team_label"
+            value={teamId}
+            onChange={handleSelectChange}
+            input={<OutlinedInput label="チーム" />}
+            MenuProps={MenuProps}
+          >
+            {teams?.map((menu) => (
+              <MenuItem key={menu.id} value={menu.id}>
+                {menu.name}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
       </Grid2>
       <Grid2 xs={12}>
         <Stack direction="row" spacing={1}>

--- a/frontend/src/components/pages/TeamsShow.tsx
+++ b/frontend/src/components/pages/TeamsShow.tsx
@@ -74,8 +74,8 @@ const TeamsShow: FC = () => {
                   onChange={handleSwitchTab}
                   textColor="inherit"
                 >
-                  <Tab label="優先度別" {...tabProps(0)} />
-                  <Tab label="納期別" {...tabProps(1)} />
+                  <Tab label="優先度" {...tabProps(0)} />
+                  <Tab label="納期" {...tabProps(1)} />
                 </Tabs>
               </Box>
             </Stack>

--- a/frontend/src/components/pages/UsersEdit.tsx
+++ b/frontend/src/components/pages/UsersEdit.tsx
@@ -13,7 +13,7 @@ import { SnackbarContext } from "../../providers/SnackbarProvider";
 import { AlertDialog } from "../ui/AlertDialog";
 import { UsersEditProfile } from "../models/user/UsersEditProfile";
 import { UsersEditPassword } from "../models/user/UsersEditPassword";
-import { BackButton } from "../ui/BackButton";
+import { BackIconButton } from "../ui/BackIconButton";
 
 const UsersEdit: FC = () => {
   const { setIsSignedIn } = useContext(AuthContext);
@@ -102,7 +102,7 @@ const UsersEdit: FC = () => {
     <Grid2 container direction="column" rowSpacing={2}>
       <Grid2 xs={12}>
         <Stack direction="row" spacing={1} alignItems="center">
-          <BackButton />
+          <BackIconButton />
           <Typography variant="h4" component="div">
             アカウント設定
           </Typography>

--- a/frontend/src/components/pages/UsersShow.tsx
+++ b/frontend/src/components/pages/UsersShow.tsx
@@ -23,7 +23,7 @@ import { DivisionsDataGrid } from "../models/user/DivisionsDataGrid";
 import { LoadingColorRing } from "../ui/LoadingColorRing";
 import { TabPanel } from "../ui/TabPanel";
 import { UserNameHeader } from "../models/user/UserNameHeader";
-import { BackButton } from "../ui/BackButton";
+import { BackIconButton } from "../ui/BackIconButton";
 
 const UsersShow: FC = () => {
   const { currentUser } = useContext(AuthContext);
@@ -138,7 +138,7 @@ const UsersShow: FC = () => {
         >
           <Grid2 xs={12}>
             <Stack direction="row" spacing={1} alignItems="center">
-              <BackButton />
+              <BackIconButton />
               <UserNameHeader user={user} />
             </Stack>
           </Grid2>

--- a/frontend/src/components/ui/BackButton.tsx
+++ b/frontend/src/components/ui/BackButton.tsx
@@ -1,6 +1,5 @@
 import { useNavigate } from "react-router-dom";
-import { IconButton, Tooltip } from "@mui/material";
-import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+import { Button } from "@mui/material";
 
 export const BackButton = () => {
   const navigate = useNavigate();
@@ -10,10 +9,8 @@ export const BackButton = () => {
   };
 
   return (
-    <Tooltip title="戻る" placement="top" arrow>
-      <IconButton size="large" onClick={handleBack}>
-        <ArrowBackIcon fontSize="inherit" />
-      </IconButton>
-    </Tooltip>
+    <Button color="secondary" onClick={handleBack}>
+      戻る
+    </Button>
   );
 };

--- a/frontend/src/components/ui/BackIconButton.tsx
+++ b/frontend/src/components/ui/BackIconButton.tsx
@@ -1,0 +1,19 @@
+import { useNavigate } from "react-router-dom";
+import { IconButton, Tooltip } from "@mui/material";
+import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+
+export const BackIconButton = () => {
+  const navigate = useNavigate();
+
+  const handleBack = () => {
+    navigate(-1);
+  };
+
+  return (
+    <Tooltip title="戻る" placement="top" arrow>
+      <IconButton size="large" onClick={handleBack}>
+        <ArrowBackIcon fontSize="inherit" />
+      </IconButton>
+    </Tooltip>
+  );
+};

--- a/frontend/src/tests/TeamsNew.test.tsx
+++ b/frontend/src/tests/TeamsNew.test.tsx
@@ -1,0 +1,38 @@
+/* eslint-disable testing-library/no-unnecessary-act */
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { act } from "react-dom/test-utils";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { SnackbarProvider } from "../providers/SnackbarProvider";
+import SignUp from "../components/pages/SignUp";
+import { AuthProvider } from "../providers/AuthProvider";
+import TeamsNew from "../components/pages/TeamsNew";
+
+describe("TeamsNew", () => {
+  test("新規チーム作成", async () => {
+    render(
+      <MemoryRouter initialEntries={["/sign_up/teams/new"]}>
+        <AuthProvider>
+          <SnackbarProvider>
+            <Routes>
+              <Route path="/sign_up/teams/new" element={<TeamsNew />} />
+              <Route path="/sign_up" element={<SignUp />} />
+            </Routes>
+          </SnackbarProvider>
+        </AuthProvider>
+      </MemoryRouter>
+    );
+
+    act(() => {
+      userEvent.type(screen.getByLabelText("新規チーム名 *"), "TEAM_NEW");
+      userEvent.click(screen.getByRole("button", { name: "作成" }));
+    });
+
+    jest.useFakeTimers();
+    act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+
+    expect(await screen.findByText("所属チーム：TEAM_NEW")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/TeamsSelect.test.tsx
+++ b/frontend/src/tests/TeamsSelect.test.tsx
@@ -3,11 +3,8 @@ import renderer from "react-test-renderer";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { act } from "react-dom/test-utils";
-import { BrowserRouter, MemoryRouter, Route, Routes } from "react-router-dom";
+import { BrowserRouter } from "react-router-dom";
 import TeamsSelect from "../components/pages/TeamsSelect";
-import { SnackbarProvider } from "../providers/SnackbarProvider";
-import SignUp from "../components/pages/SignUp";
-import { AuthProvider } from "../providers/AuthProvider";
 
 describe("TeamsSelect", () => {
   test("スナップショット", () => {
@@ -28,32 +25,5 @@ describe("TeamsSelect", () => {
     });
     expect(await screen.findByText("TEAM_1")).toBeInTheDocument();
     expect(await screen.findByText("TEAM_2")).toBeInTheDocument();
-  });
-
-  test("新規チーム作成", async () => {
-    render(
-      <MemoryRouter initialEntries={["/sign_up/teams/select"]}>
-        <AuthProvider>
-          <SnackbarProvider>
-            <Routes>
-              <Route path="/sign_up/teams/select" element={<TeamsSelect />} />
-              <Route path="/sign_up" element={<SignUp />} />
-            </Routes>
-          </SnackbarProvider>
-        </AuthProvider>
-      </MemoryRouter>
-    );
-
-    act(() => {
-      userEvent.type(screen.getByLabelText("新規チーム名 *"), "TEAM_NEW");
-      userEvent.click(screen.getByRole("button", { name: "作成" }));
-    });
-
-    jest.useFakeTimers();
-    act(() => {
-      jest.advanceTimersByTime(3000);
-    });
-
-    expect(await screen.findByText("所属チーム：TEAM_NEW")).toBeInTheDocument();
   });
 });

--- a/frontend/src/tests/__snapshots__/TeamsSelect.test.tsx.snap
+++ b/frontend/src/tests/__snapshots__/TeamsSelect.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`TeamsSelect スナップショット 1`] = `
       所属チームの選択
     </div>
     <div
-      className="MuiTypography-root MuiTypography-subtitle1 css-10wpov9-MuiTypography-root"
+      className="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
     >
       選択したチームでユーザー登録します。
     </div>
@@ -22,13 +22,12 @@ exports[`TeamsSelect スナップショット 1`] = `
     className="MuiGrid2-root MuiGrid2-grid-xs-12 css-16fnxy3-MuiGrid2-root"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root css-tghzsf-MuiFormControl-root-MuiTextField-root"
+      className="MuiFormControl-root css-1wmrndo-MuiFormControl-root"
     >
       <label
         className="MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-root MuiFormLabel-colorSecondary Mui-required css-1v4qvbo-MuiFormLabel-root-MuiInputLabel-root"
         data-shrink={false}
-        htmlFor=":r0:"
-        id=":r0:-label"
+        id="team_label"
       >
         チーム
         <span
@@ -47,9 +46,8 @@ exports[`TeamsSelect スナップショット 1`] = `
         <div
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-labelledby=":r0:-label :r0:"
+          aria-labelledby="team_label"
           className="MuiSelect-select MuiSelect-outlined MuiOutlinedInput-input MuiInputBase-input css-11u53oe-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
-          id=":r0:"
           onBlur={[Function]}
           onFocus={[Function]}
           onKeyDown={[Function]}
@@ -65,10 +63,8 @@ exports[`TeamsSelect スナップショット 1`] = `
         </div>
         <input
           aria-hidden={true}
-          autoFocus={false}
           className="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
           disabled={false}
-          name="id"
           onAnimationStart={[Function]}
           onChange={[Function]}
           required={true}
@@ -106,43 +102,57 @@ exports[`TeamsSelect スナップショット 1`] = `
   <div
     className="MuiGrid2-root MuiGrid2-grid-xs-12 css-16fnxy3-MuiGrid2-root"
   >
-    <button
-      className="MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root  css-sghohy-MuiButtonBase-root-MuiButton-root"
-      disabled={false}
-      onBlur={[Function]}
-      onContextMenu={[Function]}
-      onDragLeave={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      tabIndex={0}
-      type="button"
+    <div
+      className="css-w4z10b-MuiStack-root"
     >
       <a
+        className="MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root  css-sghohy-MuiButtonBase-root-MuiButton-root"
         href="/sign_up"
+        onBlur={[Function]}
         onClick={[Function]}
-        style={
-          Object {
-            "color": "black",
-            "textDecoration": "none",
-          }
-        }
+        onContextMenu={[Function]}
+        onDragLeave={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
+        tabIndex={0}
       >
         次へ
       </a>
-    </button>
+      <button
+        className="MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButtonBase-root  css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+        disabled={false}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onContextMenu={[Function]}
+        onDragLeave={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
+        tabIndex={0}
+        type="button"
+      >
+        戻る
+      </button>
+    </div>
   </div>
   <div
     className="MuiGrid2-root MuiGrid2-grid-xs-12 css-16fnxy3-MuiGrid2-root"
   >
     <div
-      className="MuiTypography-root MuiTypography-subtitle1 css-iehxsa-MuiTypography-root"
+      className="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
     >
       または
     </div>
@@ -150,87 +160,9 @@ exports[`TeamsSelect スナップショット 1`] = `
   <div
     className="MuiGrid2-root MuiGrid2-grid-xs-12 css-16fnxy3-MuiGrid2-root"
   >
-    <div
-      className="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom css-1vw6mcs-MuiTypography-root"
-    >
-      新規チーム作成
-    </div>
-    <div
-      className="MuiTypography-root MuiTypography-subtitle1 css-10wpov9-MuiTypography-root"
-    >
-      新しいチームの管理者としてユーザー登録します。
-    </div>
-  </div>
-  <div
-    className="MuiGrid2-root MuiGrid2-grid-xs-12 css-16fnxy3-MuiGrid2-root"
-  >
-    <div
-      className="MuiFormControl-root MuiTextField-root css-tghzsf-MuiFormControl-root-MuiTextField-root"
-    >
-      <label
-        className="MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-root MuiFormLabel-colorSecondary Mui-required css-1v4qvbo-MuiFormLabel-root-MuiInputLabel-root"
-        data-shrink={false}
-        htmlFor=":r1:"
-        id=":r1:-label"
-      >
-        新規チーム名
-        <span
-          aria-hidden={true}
-          className="MuiInputLabel-asterisk MuiFormLabel-asterisk css-wgai2y-MuiFormLabel-asterisk"
-        >
-           
-          *
-        </span>
-      </label>
-      <div
-        className="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorSecondary MuiInputBase-formControl css-hjtp1-MuiInputBase-root-MuiOutlinedInput-root"
-        onClick={[Function]}
-      >
-        <input
-          aria-describedby=":r1:-helper-text"
-          aria-invalid={false}
-          autoFocus={false}
-          className="MuiOutlinedInput-input MuiInputBase-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-          disabled={false}
-          id=":r1:"
-          maxLength={20}
-          onAnimationStart={[Function]}
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          required={true}
-          type="text"
-          value=""
-        />
-        <fieldset
-          aria-hidden={true}
-          className="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
-        >
-          <legend
-            className="css-1ftyaf0"
-          >
-            <span>
-              新規チーム名
-               
-              *
-            </span>
-          </legend>
-        </fieldset>
-      </div>
-      <p
-        className="MuiFormHelperText-root MuiFormHelperText-sizeMedium MuiFormHelperText-contained Mui-required css-1wc848c-MuiFormHelperText-root"
-        id=":r1:-helper-text"
-      >
-        20文字以内
-      </p>
-    </div>
-  </div>
-  <div
-    className="MuiGrid2-root MuiGrid2-grid-xs-12 css-16fnxy3-MuiGrid2-root"
-  >
-    <button
-      className="MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root  css-sghohy-MuiButtonBase-root-MuiButton-root"
-      disabled={false}
+    <a
+      className="MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root  css-zcbmsk-MuiButtonBase-root-MuiButton-root"
+      href="/sign_up/teams/new"
       onBlur={[Function]}
       onClick={[Function]}
       onContextMenu={[Function]}
@@ -245,10 +177,9 @@ exports[`TeamsSelect スナップショット 1`] = `
       onTouchMove={[Function]}
       onTouchStart={[Function]}
       tabIndex={0}
-      type="submit"
     >
-      作成
-    </button>
+      新規チーム作成
+    </a>
   </div>
 </div>
 `;


### PR DESCRIPTION
### 変更内容
**backend**
- `teams#select`で`max_num_of_user`に達していない`team`のみ抽出するよう修正
- `counter_culture`のインストール
- `Team`テーブルに`users_count`カラムを追加

**frontend**
- `TeamsNew`ページの作成
- パブリックルートに戻るボタンを設置
- 選択ボックスのメニューサイズを設定
- テスト作成