### PR TITLE
fix: DataGridレイアウト修正

### DIFF
--- a/frontend/src/components/models/user/DivisionsDataGrid.tsx
+++ b/frontend/src/components/models/user/DivisionsDataGrid.tsx
@@ -23,7 +23,7 @@ export const DivisionsDataGrid = (props: Props) => {
     parent_user_avatar: division.parent_user_avatar,
     parent_user_name: division.parent_user
       ? division.parent_user.name
-      : "退会済みユーザー",
+      : "不明なユーザー",
     child_task_id: division.child_task ? division.child_task.id : undefined,
     child_task_title: division.child_task
       ? division.child_task.title
@@ -32,7 +32,7 @@ export const DivisionsDataGrid = (props: Props) => {
     child_user_avatar: division.child_user_avatar,
     child_user_name: division.child_user
       ? division.child_user.name
-      : "退会済みユーザー",
+      : "不明なユーザー",
     comment: division.comment,
     created_at: DatetimeFormat(division.created_at),
   }));

--- a/frontend/src/components/models/user/FinishedTasksColumns.tsx
+++ b/frontend/src/components/models/user/FinishedTasksColumns.tsx
@@ -1,0 +1,69 @@
+import { useContext } from "react";
+import { Link as RouterLink } from "react-router-dom";
+import { Chip, Stack, IconButton, Link, Tooltip } from "@mui/material";
+import { GridColDef } from "@mui/x-data-grid";
+import EditIcon from "@mui/icons-material/Edit";
+import { TasksDeleteIconButton } from "../task/TasksDeleteIconButton";
+import { PriorityChipProps } from "./PriorityChipProps";
+import { AuthContext } from "../../../providers/AuthProvider";
+import { User } from "../../../types/userTypes";
+
+export const FinishedTasksColumns = (user: User | undefined) => {
+  const { currentUser } = useContext(AuthContext);
+
+  const finishedTasksColumns: GridColDef[] = [
+    {
+      field: "title",
+      headerName: "タイトル",
+      width: 200,
+      renderCell: (params) => (
+        <Link
+          color="inherit"
+          underline="hover"
+          component={RouterLink}
+          to={`/tasks/${params.id}`}
+        >
+          {params.value}
+        </Link>
+      ),
+    },
+    { field: "description", headerName: "詳細", width: 200 },
+    {
+      field: "priority",
+      headerName: "重要度",
+      width: 100,
+      renderCell: (params) => (
+        <Chip
+          variant="outlined"
+          sx={{ height: 28 }}
+          {...PriorityChipProps(params)}
+        />
+      ),
+    },
+    { field: "deadline", headerName: "納期", width: 150 },
+    { field: "updated_at", headerName: "完了日", width: 150 },
+    {
+      field: "actions",
+      headerName: "アクション",
+      width: 100,
+      renderCell: (params) =>
+        user?.id === currentUser?.id ? (
+          <Stack direction="row" spacing={1}>
+            <Tooltip title="編集" placement="top" arrow>
+              <IconButton
+                component={RouterLink}
+                to={`/tasks/${params.id}/edit`}
+              >
+                <EditIcon />
+              </IconButton>
+            </Tooltip>
+            <TasksDeleteIconButton taskId={params.id} />
+          </Stack>
+        ) : null,
+      sortable: false,
+      disableColumnMenu: true,
+    },
+  ];
+
+  return finishedTasksColumns;
+};

--- a/frontend/src/components/models/user/TasksActionButtons.tsx
+++ b/frontend/src/components/models/user/TasksActionButtons.tsx
@@ -45,7 +45,7 @@ export const TasksActionButtons = (props: Props) => {
         sx={{ display: { xs: "flex", md: "none" } }}
       >
         <TasksNewButton />
-        {tabValue === 2 || (
+        {tabValue === 2 ? null : (
           <Stack direction="row" spacing={1}>
             <IsDoneUpdateButton
               onClick={handleMultiIsDoneUpdate}
@@ -74,7 +74,7 @@ export const TasksActionButtons = (props: Props) => {
         sx={{ display: { xs: "none", md: "flex" } }}
       >
         <TasksNewButton />
-        {tabValue === 2 || (
+        {tabValue === 2 ? null : (
           <Stack direction="row" spacing={2}>
             <IsDoneUpdateButton
               onClick={handleMultiIsDoneUpdate}

--- a/frontend/src/components/models/user/TasksDataGrid.tsx
+++ b/frontend/src/components/models/user/TasksDataGrid.tsx
@@ -1,21 +1,12 @@
 import { Dispatch, SetStateAction, useContext } from "react";
-import { Link as RouterLink } from "react-router-dom";
-import { Link, Box, Chip, IconButton, Stack, Tooltip } from "@mui/material";
-import {
-  DataGrid,
-  GridCellParams,
-  GridColDef,
-  GridRowId,
-} from "@mui/x-data-grid";
-import ConnectWithoutContactIcon from "@mui/icons-material/ConnectWithoutContact";
-import EditIcon from "@mui/icons-material/Edit";
-import clsx from "clsx";
-import { PriorityChipProps } from "./PriorityChipProps";
+import { Box } from "@mui/material";
+import { DataGrid, GridRowId } from "@mui/x-data-grid";
 import { User } from "../../../types/userTypes";
 import { Task } from "../../../types/taskTypes";
 import { DatetimeFormat } from "../../ui/DatetimeFormat";
 import { AuthContext } from "../../../providers/AuthProvider";
-import { TasksDeleteIconButton } from "../task/TasksDeleteIconButton";
+import { UnfinishedTasksColumns } from "./UnfinishedTasksColumns";
+import { FinishedTasksColumns } from "./FinishedTasksColumns";
 
 type Props = {
   isFinished: boolean;
@@ -28,6 +19,8 @@ type Props = {
 export const TasksDataGrid = (props: Props) => {
   const { isFinished, user, tasks, selectionModel, setSelectionModel } = props;
   const { currentUser } = useContext(AuthContext);
+  const unfinishedTasksColumns = UnfinishedTasksColumns(user);
+  const finishedTasksColumns = FinishedTasksColumns(user);
 
   const rows = tasks?.map((task) => ({
     id: task.id,
@@ -38,138 +31,6 @@ export const TasksDataGrid = (props: Props) => {
     rateOfProgress: `${task.rate_of_progress}%`,
     updated_at: DatetimeFormat(task.updated_at),
   }));
-
-  const unfinishedTasksColumns: GridColDef[] = [
-    {
-      field: "title",
-      headerName: "タイトル",
-      width: 200,
-      renderCell: (params) => (
-        <Link
-          color="inherit"
-          underline="hover"
-          component={RouterLink}
-          to={`/tasks/${params.id}`}
-        >
-          {params.value}
-        </Link>
-      ),
-    },
-    { field: "description", headerName: "詳細", width: 200 },
-    {
-      field: "priority",
-      headerName: "重要度",
-      width: 100,
-      renderCell: (params) => (
-        <Chip
-          variant="outlined"
-          sx={{ height: 28 }}
-          {...PriorityChipProps(params)}
-        />
-      ),
-    },
-    {
-      field: "deadline",
-      headerName: "納期",
-      width: 150,
-      cellClassName: (params: GridCellParams<string>) => {
-        if (params.value === undefined) {
-          return "";
-        }
-        return clsx("deadline", {
-          over: new Date(params.value.toString()) < new Date(),
-        });
-      },
-    },
-    { field: "rateOfProgress", headerName: "進捗率", width: 100 },
-    {
-      field: "actions",
-      headerName: "",
-      width: 150,
-      renderCell: (params) => (
-        <Stack direction="row" spacing={1}>
-          <Tooltip title="分担する" placement="top" arrow>
-            <IconButton
-              color="secondary"
-              component={RouterLink}
-              to={`/tasks/${params.id}/divisions/new`}
-            >
-              <ConnectWithoutContactIcon />
-            </IconButton>
-          </Tooltip>
-          {user?.id === currentUser?.id ? (
-            <>
-              <Tooltip title="編集" placement="top" arrow>
-                <IconButton
-                  component={RouterLink}
-                  to={`/tasks/${params.id}/edit`}
-                >
-                  <EditIcon />
-                </IconButton>
-              </Tooltip>
-              <TasksDeleteIconButton taskId={params.id} />
-            </>
-          ) : null}
-        </Stack>
-      ),
-      sortable: false,
-      disableColumnMenu: true,
-    },
-  ];
-
-  const finishedTasksColumns: GridColDef[] = [
-    {
-      field: "title",
-      headerName: "タイトル",
-      width: 200,
-      renderCell: (params) => (
-        <Link
-          color="inherit"
-          underline="hover"
-          component={RouterLink}
-          to={`/tasks/${params.id}`}
-        >
-          {params.value}
-        </Link>
-      ),
-    },
-    { field: "description", headerName: "詳細", width: 200 },
-    {
-      field: "priority",
-      headerName: "重要度",
-      width: 100,
-      renderCell: (params) => (
-        <Chip
-          variant="outlined"
-          sx={{ height: 28 }}
-          {...PriorityChipProps(params)}
-        />
-      ),
-    },
-    { field: "deadline", headerName: "納期", width: 150 },
-    { field: "updated_at", headerName: "完了日", width: 150 },
-    {
-      field: "actions",
-      headerName: "",
-      width: 100,
-      renderCell: (params) =>
-        user?.id === currentUser?.id ? (
-          <Stack direction="row" spacing={1}>
-            <Tooltip title="編集" placement="top" arrow>
-              <IconButton
-                component={RouterLink}
-                to={`/tasks/${params.id}/edit`}
-              >
-                <EditIcon />
-              </IconButton>
-            </Tooltip>
-            <TasksDeleteIconButton taskId={params.id} />
-          </Stack>
-        ) : null,
-      sortable: false,
-      disableColumnMenu: true,
-    },
-  ];
 
   return (
     <Box

--- a/frontend/src/components/models/user/UnfinishedTasksColumns.tsx
+++ b/frontend/src/components/models/user/UnfinishedTasksColumns.tsx
@@ -1,0 +1,95 @@
+import { useContext } from "react";
+import { Link as RouterLink } from "react-router-dom";
+import { Chip, Stack, IconButton, Link, Tooltip } from "@mui/material";
+import { GridColDef, GridCellParams } from "@mui/x-data-grid";
+import ConnectWithoutContactIcon from "@mui/icons-material/ConnectWithoutContact";
+import EditIcon from "@mui/icons-material/Edit";
+import clsx from "clsx";
+import { TasksDeleteIconButton } from "../task/TasksDeleteIconButton";
+import { PriorityChipProps } from "./PriorityChipProps";
+import { AuthContext } from "../../../providers/AuthProvider";
+import { User } from "../../../types/userTypes";
+
+export const UnfinishedTasksColumns = (user: User | undefined) => {
+  const { currentUser } = useContext(AuthContext);
+
+  const unfinishedTasksColumns: GridColDef[] = [
+    {
+      field: "title",
+      headerName: "タイトル",
+      width: 200,
+      renderCell: (params) => (
+        <Link
+          color="inherit"
+          underline="hover"
+          component={RouterLink}
+          to={`/tasks/${params.id}`}
+        >
+          {params.value}
+        </Link>
+      ),
+    },
+    { field: "description", headerName: "詳細", width: 200 },
+    {
+      field: "priority",
+      headerName: "重要度",
+      width: 100,
+      renderCell: (params) => (
+        <Chip
+          variant="outlined"
+          sx={{ height: 28 }}
+          {...PriorityChipProps(params)}
+        />
+      ),
+    },
+    {
+      field: "deadline",
+      headerName: "納期",
+      width: 150,
+      cellClassName: (params: GridCellParams<string>) => {
+        if (params.value === undefined) {
+          return "";
+        }
+        return clsx("deadline", {
+          over: new Date(params.value.toString()) < new Date(),
+        });
+      },
+    },
+    { field: "rateOfProgress", headerName: "進捗率", width: 100 },
+    {
+      field: "actions",
+      headerName: "アクション",
+      width: 150,
+      renderCell: (params) => (
+        <Stack direction="row" spacing={1}>
+          <Tooltip title="分担する" placement="top" arrow>
+            <IconButton
+              color="secondary"
+              component={RouterLink}
+              to={`/tasks/${params.id}/divisions/new`}
+            >
+              <ConnectWithoutContactIcon />
+            </IconButton>
+          </Tooltip>
+          {user?.id === currentUser?.id ? (
+            <>
+              <Tooltip title="編集" placement="top" arrow>
+                <IconButton
+                  component={RouterLink}
+                  to={`/tasks/${params.id}/edit`}
+                >
+                  <EditIcon />
+                </IconButton>
+              </Tooltip>
+              <TasksDeleteIconButton taskId={params.id} />
+            </>
+          ) : null}
+        </Stack>
+      ),
+      sortable: false,
+      disableColumnMenu: true,
+    },
+  ];
+
+  return unfinishedTasksColumns;
+};

--- a/frontend/src/components/pages/UsersShow.tsx
+++ b/frontend/src/components/pages/UsersShow.tsx
@@ -51,30 +51,6 @@ export const UsersShow = () => {
     []
   );
 
-  const unfinishedTasksDataGrid = (
-    <TasksDataGrid
-      isFinished={false}
-      user={userData?.user}
-      tasks={userData?.unfinished_tasks}
-      selectionModel={selectionModel}
-      setSelectionModel={setSelectionModel}
-    />
-  );
-
-  const finishedTasksDataGrid = (
-    <TasksDataGrid
-      isFinished
-      user={userData?.user}
-      tasks={userData?.finished_tasks}
-      selectionModel={selectionModel}
-      setSelectionModel={setSelectionModel}
-    />
-  );
-
-  const divisionsDataGrid = (
-    <DivisionsDataGrid divisions={userData?.divisions} />
-  );
-
   useEffect(() => {
     if (userData?.unfinished_tasks && tabValue === 0) {
       setIsFinished(false);
@@ -153,13 +129,25 @@ export const UsersShow = () => {
           sx={{ width: { xs: 330, sm: 560, md: 850, lg: 900, xl: 1050 } }}
         >
           <TabPanel value={tabValue} index={0}>
-            {unfinishedTasksDataGrid}
+            <TasksDataGrid
+              isFinished={false}
+              user={userData?.user}
+              tasks={userData?.unfinished_tasks}
+              selectionModel={selectionModel}
+              setSelectionModel={setSelectionModel}
+            />
           </TabPanel>
           <TabPanel value={tabValue} index={1}>
-            {finishedTasksDataGrid}
+            <TasksDataGrid
+              isFinished
+              user={userData?.user}
+              tasks={userData?.finished_tasks}
+              selectionModel={selectionModel}
+              setSelectionModel={setSelectionModel}
+            />
           </TabPanel>
           <TabPanel value={tabValue} index={2}>
-            {divisionsDataGrid}
+            <DivisionsDataGrid divisions={userData?.divisions} />
           </TabPanel>
         </Grid2>
       </Grid2>


### PR DESCRIPTION
### 変更内容
- `TasksDataGrid`のカラムをコンポーネント化
- `TasksDataGrid`のカラム名を修正
- `DivisionsDataGrid`の`退会済みユーザー`を`不明なユーザー`に変更