### PR TITLE
fix: レイアウト修正 #199

### DIFF
--- a/frontend/src/components/models/task/UpdateIsDoneButton.tsx
+++ b/frontend/src/components/models/task/UpdateIsDoneButton.tsx
@@ -1,5 +1,6 @@
 import { Button, IconButton } from "@mui/material";
 import CheckIcon from "@mui/icons-material/Check";
+import KeyboardReturnIcon from "@mui/icons-material/KeyboardReturn";
 
 type Props = {
   onClick: () => void;
@@ -18,7 +19,7 @@ export const UpdateIsDoneButton = (props: Props) => {
         disabled={disabled}
         sx={{ display: { xs: "flex", md: "none" } }}
       >
-        <CheckIcon />
+        {isFinished ? <KeyboardReturnIcon /> : <CheckIcon />}
       </IconButton>
       <Button
         color="secondary"

--- a/frontend/src/components/models/team/DeadlineBarChart.tsx
+++ b/frontend/src/components/models/team/DeadlineBarChart.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from "react";
 import {
   Bar,
   BarChart,
@@ -18,17 +17,14 @@ type Props = {
 export const DeadlineBarChart = (props: Props) => {
   const { user, maxCount } = props;
 
-  const data = useMemo(
-    () => [
-      {
-        name: user.name,
-        "3日以内": user.unfinished_tasks_deadline_count[2],
-        "4日〜7日以内": user.unfinished_tasks_deadline_count[1],
-        "8日以上": user.unfinished_tasks_deadline_count[0],
-      },
-    ],
-    [user]
-  );
+  const data = [
+    {
+      name: user.name,
+      "3日以内": user.unfinished_tasks_deadline_count[2],
+      "4日〜7日以内": user.unfinished_tasks_deadline_count[1],
+      "8日以上": user.unfinished_tasks_deadline_count[0],
+    },
+  ];
 
   return (
     <ResponsiveContainer width="100%" height={70}>

--- a/frontend/src/components/models/team/DeadlineBarChart.tsx
+++ b/frontend/src/components/models/team/DeadlineBarChart.tsx
@@ -39,7 +39,7 @@ export const DeadlineBarChart = (props: Props) => {
             style={{ fontFamily: "roboto" }}
           />
         </Bar>
-        <Bar dataKey="4日〜7日以内" stackId="a" fill="#ffd600">
+        <Bar dataKey="4日〜7日以内" stackId="a" fill="#ffc107">
           <LabelList
             dataKey="4日〜7日以内"
             position="top"

--- a/frontend/src/components/models/team/PriorityBarChart.tsx
+++ b/frontend/src/components/models/team/PriorityBarChart.tsx
@@ -56,7 +56,7 @@ export const PriorityBarChart = (props: Props) => {
         <Bar
           dataKey="中"
           stackId="a"
-          fill="#ffd600"
+          fill="#ffc107"
           isAnimationActive={animate}
           onAnimationStart={onAnimationStart}
         >

--- a/frontend/src/components/models/team/PriorityBarChart.tsx
+++ b/frontend/src/components/models/team/PriorityBarChart.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useState } from "react";
 import {
   Bar,
   BarChart,
@@ -25,17 +25,14 @@ export const PriorityBarChart = (props: Props) => {
     }, 2000);
   }, []);
 
-  const data = useMemo(
-    () => [
-      {
-        name: user.name,
-        高: user.unfinished_tasks_priority_count[2],
-        中: user.unfinished_tasks_priority_count[1],
-        低: user.unfinished_tasks_priority_count[0],
-      },
-    ],
-    [user]
-  );
+  const data = [
+    {
+      name: user.name,
+      高: user.unfinished_tasks_priority_count[2],
+      中: user.unfinished_tasks_priority_count[1],
+      低: user.unfinished_tasks_priority_count[0],
+    },
+  ];
 
   return (
     <ResponsiveContainer width="100%" height={70}>

--- a/frontend/src/components/pages/DivisionsNew.tsx
+++ b/frontend/src/components/pages/DivisionsNew.tsx
@@ -12,6 +12,7 @@ import {
   Typography,
 } from "@mui/material";
 import Grid2 from "@mui/material/Unstable_Grid2/Grid2";
+import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
 import { User } from "../../types/userTypes";
 import { DivisionTask } from "../../types/taskTypes";
 import { TasksForm } from "../models/task/TasksForm";
@@ -139,8 +140,9 @@ export const DivisionsNew = () => {
           variant="contained"
           type="submit"
           onClick={handleCreateDivision}
+          startIcon={<AutoAwesomeIcon />}
         >
-          完了
+          分担する
         </Button>
       </Grid2>
     </Grid2>

--- a/frontend/src/components/ui/DrawerHeader.tsx
+++ b/frontend/src/components/ui/DrawerHeader.tsx
@@ -1,0 +1,10 @@
+import { styled } from "@mui/material";
+
+export const DrawerHeader = styled("div")(({ theme }) => ({
+  display: "flex",
+  alignItems: "center",
+  padding: theme.spacing(0, 1),
+  // necessary for content to be below app bar
+  ...theme.mixins.toolbar,
+  justifyContent: "flex-end",
+}));

--- a/frontend/src/components/ui/DrawerList.tsx
+++ b/frontend/src/components/ui/DrawerList.tsx
@@ -1,0 +1,68 @@
+import { useCallback } from "react";
+import { Link } from "react-router-dom";
+import {
+  Divider,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  ListItemAvatar,
+  Avatar,
+} from "@mui/material";
+import StarIcon from "@mui/icons-material/Star";
+import { TeamsShowResponse } from "../../types/teamTypes";
+
+type Props = {
+  onClose: () => void;
+  teamData: TeamsShowResponse | undefined;
+};
+
+export const DrawerList = (props: Props) => {
+  const { onClose, teamData } = props;
+
+  const unfinishedTasksCount = useCallback((tasks: number[]) => {
+    const total = tasks.reduce((sum: number, element: number) => {
+      return sum + element;
+    }, 0);
+    return total;
+  }, []);
+
+  return (
+    <div>
+      <Divider />
+      <List>
+        <ListItem disablePadding>
+          <ListItemButton component={Link} to="/teams" onClick={onClose}>
+            <ListItemIcon>
+              <StarIcon />
+            </ListItemIcon>
+            <ListItemText
+              primary={teamData?.team?.name}
+              secondary={`${teamData?.users?.length}人のメンバー`}
+            />
+          </ListItemButton>
+        </ListItem>
+        {teamData?.users?.map((user) => (
+          <ListItem key={user.id} disablePadding>
+            <ListItemButton
+              component={Link}
+              to={`/users/${user.id}`}
+              onClick={onClose}
+            >
+              <ListItemAvatar>
+                <Avatar src={user.avatar} alt="avatar" />
+              </ListItemAvatar>
+              <ListItemText
+                primary={user.name}
+                secondary={`${unfinishedTasksCount(
+                  user.unfinished_tasks_priority_count
+                )}件のタスク`}
+              />
+            </ListItemButton>
+          </ListItem>
+        ))}
+      </List>
+    </div>
+  );
+};

--- a/frontend/src/components/ui/Header.tsx
+++ b/frontend/src/components/ui/Header.tsx
@@ -29,6 +29,7 @@ export const Header = (props: Props) => {
           xs: 1199,
           lg: 1201,
         },
+        height: { xs: 56, sm: 64 },
       }}
     >
       <Toolbar>
@@ -67,15 +68,11 @@ export const Header = (props: Props) => {
               <Button
                 component={Link}
                 to="/sign_up/teams/select"
-                sx={{ my: { xs: 1, md: 2 }, color: "black" }}
+                sx={{ color: "black" }}
               >
                 ユーザー登録
               </Button>
-              <Button
-                component={Link}
-                to="/sign_in"
-                sx={{ my: { xs: 1, md: 2 }, color: "black" }}
-              >
+              <Button component={Link} to="/sign_in" sx={{ color: "black" }}>
                 ログイン
               </Button>
             </Box>

--- a/frontend/src/components/ui/LeftDrawer.tsx
+++ b/frontend/src/components/ui/LeftDrawer.tsx
@@ -1,83 +1,33 @@
-import { useCallback, useEffect } from "react";
-import { Link } from "react-router-dom";
-import {
-  Divider,
-  Drawer,
-  List,
-  ListItem,
-  ListItemButton,
-  ListItemText,
-  Toolbar,
-  Box,
-  Avatar,
-  ListItemAvatar,
-  ListItemIcon,
-} from "@mui/material";
-import StarIcon from "@mui/icons-material/Star";
+import { Dispatch, SetStateAction, useEffect } from "react";
+import { Drawer, Toolbar, Box, IconButton, useTheme } from "@mui/material";
+import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
+import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 import { useFetchTeam } from "../../hooks/team/useFetchTeam";
+import { DrawerHeader } from "./DrawerHeader";
+import { DrawerList } from "./DrawerList";
 
 type Props = {
   // eslint-disable-next-line react/require-default-props
   window?: () => Window;
   open: boolean;
+  setOpen: Dispatch<SetStateAction<boolean>>;
   onClose: () => void;
 };
 
 export const LeftDrawer = (props: Props) => {
-  const { window, open, onClose } = props;
+  const { window, open, setOpen, onClose } = props;
+  const theme = useTheme();
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const [teamData, isLoading, error] = useFetchTeam();
 
   const drawerWidth = 240;
 
-  const unfinishedTasksCount = useCallback((tasks: number[]) => {
-    const total = tasks.reduce((sum: number, element: number) => {
-      return sum + element;
-    }, 0);
-    return total;
-  }, []);
-
   const container =
     window !== undefined ? () => window().document.body : undefined;
 
-  const drawer = (
-    <div>
-      <Toolbar />
-      <Divider />
-      <List>
-        <ListItem disablePadding>
-          <ListItemButton component={Link} to="/teams" onClick={onClose}>
-            <ListItemIcon>
-              <StarIcon />
-            </ListItemIcon>
-            <ListItemText
-              primary={teamData?.team?.name}
-              secondary={`${teamData?.users?.length}人のメンバー`}
-            />
-          </ListItemButton>
-        </ListItem>
-        {teamData?.users?.map((user) => (
-          <ListItem key={user.id} disablePadding>
-            <ListItemButton
-              component={Link}
-              to={`/users/${user.id}`}
-              onClick={onClose}
-            >
-              <ListItemAvatar>
-                <Avatar src={user.avatar} alt="avatar" />
-              </ListItemAvatar>
-              <ListItemText
-                primary={user.name}
-                secondary={`${unfinishedTasksCount(
-                  user.unfinished_tasks_priority_count
-                )}件のタスク`}
-              />
-            </ListItemButton>
-          </ListItem>
-        ))}
-      </List>
-    </div>
-  );
+  const handleDrawerClose = () => {
+    setOpen(false);
+  };
 
   useEffect(() => {
     if (error) {
@@ -97,7 +47,7 @@ export const LeftDrawer = (props: Props) => {
       >
         <Drawer
           container={container}
-          variant="temporary"
+          variant="persistent"
           open={open}
           onClose={onClose}
           ModalProps={{
@@ -112,7 +62,16 @@ export const LeftDrawer = (props: Props) => {
             },
           }}
         >
-          {drawer}
+          <DrawerHeader>
+            <IconButton onClick={handleDrawerClose}>
+              {theme.direction === "ltr" ? (
+                <ChevronLeftIcon />
+              ) : (
+                <ChevronRightIcon />
+              )}
+            </IconButton>
+          </DrawerHeader>
+          <DrawerList onClose={onClose} teamData={teamData} />
         </Drawer>
         <Drawer
           variant="permanent"
@@ -125,7 +84,8 @@ export const LeftDrawer = (props: Props) => {
             },
           }}
         >
-          {drawer}
+          <Toolbar />
+          <DrawerList onClose={onClose} teamData={teamData} />
         </Drawer>
       </Box>
     </div>

--- a/frontend/src/components/ui/MenuBars.tsx
+++ b/frontend/src/components/ui/MenuBars.tsx
@@ -16,7 +16,11 @@ export const MenuBars = () => {
     <Box>
       <Header onClick={handleDrawerToggle} />
       {isSignedIn ? (
-        <LeftDrawer open={open} onClose={handleDrawerToggle} />
+        <LeftDrawer
+          open={open}
+          setOpen={setOpen}
+          onClose={handleDrawerToggle}
+        />
       ) : null}
     </Box>
   );


### PR DESCRIPTION
### 変更内容
**frontend**
- 分担完了ボタンの修正
- スマホ用`Drawer`を`persistent`に変更
- `Header`の`height`を指定
- グラフ色を黄色からオレンジに修正
- 未了/完了ボタンのスマホ用アイコンを修正