### PR TITLE
refactor: 型定義名の修正 #183

### DIFF
--- a/frontend/src/components/models/task/TasksForm.tsx
+++ b/frontend/src/components/models/task/TasksForm.tsx
@@ -7,13 +7,13 @@ import {
   TextField,
 } from "@mui/material";
 import Grid2 from "@mui/material/Unstable_Grid2/Grid2";
-import { DivisionTask, EditTask } from "../../../types/taskTypes";
+import { DividedTask, EditTask } from "../../../types/taskTypes";
 import { PriorityTextField } from "./PriorityTextField";
 import { DeadlineTextField } from "./DeadlineTextField";
 
 type Props = {
   action: string;
-  task: EditTask | DivisionTask;
+  task: EditTask | DividedTask;
   onChange: (event: ChangeEvent<HTMLInputElement>) => void;
   deadline: Date | null;
   onChangeDeadline: (newValue: Date | null) => void;

--- a/frontend/src/components/models/user/DivisionsDataGrid.tsx
+++ b/frontend/src/components/models/user/DivisionsDataGrid.tsx
@@ -3,11 +3,11 @@
 import { Link as RouterLink } from "react-router-dom";
 import { Link, Avatar, Stack, Typography } from "@mui/material";
 import { DataGrid, GridColDef } from "@mui/x-data-grid";
-import { DivisionHistory } from "../../../types/divisionTypes";
+import { DividedHistory } from "../../../types/divisionTypes";
 import { DatetimeFormat } from "../../ui/DatetimeFormat";
 
 type Props = {
-  divisions: DivisionHistory[] | undefined;
+  divisions: DividedHistory[] | undefined;
 };
 
 export const DivisionsDataGrid = (props: Props) => {

--- a/frontend/src/components/pages/DivisionsNew.tsx
+++ b/frontend/src/components/pages/DivisionsNew.tsx
@@ -14,7 +14,7 @@ import {
 import Grid2 from "@mui/material/Unstable_Grid2/Grid2";
 import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
 import { User } from "../../types/userTypes";
-import { DivisionTask } from "../../types/taskTypes";
+import { DividedTask } from "../../types/taskTypes";
 import { TasksForm } from "../models/task/TasksForm";
 import { BackIconButton } from "../ui/BackIconButton";
 import { usePostDivision } from "../../hooks/division/usePostDivision";
@@ -24,7 +24,7 @@ import { LoadingColorRing } from "../ui/LoadingColorRing";
 export const DivisionsNew = () => {
   const [divisionData, isLoading] = useFetchNewDivision();
 
-  const [task, setTask] = useState<DivisionTask>({
+  const [task, setTask] = useState<DividedTask>({
     title: "",
     description: "",
     priority: "",

--- a/frontend/src/components/ui/DrawerList.tsx
+++ b/frontend/src/components/ui/DrawerList.tsx
@@ -11,11 +11,11 @@ import {
   Avatar,
 } from "@mui/material";
 import StarIcon from "@mui/icons-material/Star";
-import { TeamsShowResponse } from "../../types/teamTypes";
+import { FetchTeamResponse } from "../../types/teamTypes";
 
 type Props = {
   onClose: () => void;
-  teamData: TeamsShowResponse | undefined;
+  teamData: FetchTeamResponse | undefined;
 };
 
 export const DrawerList = (props: Props) => {

--- a/frontend/src/hooks/division/usePostDivision.ts
+++ b/frontend/src/hooks/division/usePostDivision.ts
@@ -6,10 +6,10 @@ import { baseAxios } from "../../apis/axios";
 import { PostDivisionResponse } from "../../types/divisionTypes";
 import { AuthContext } from "../../providers/AuthProvider";
 import { SnackbarContext } from "../../providers/SnackbarProvider";
-import { DivisionTask } from "../../types/taskTypes";
+import { DividedTask } from "../../types/taskTypes";
 
 type Props = {
-  task: DivisionTask | undefined;
+  task: DividedTask | undefined;
   deadline: Date | null;
   comment: string;
   teamMemberValue: string;

--- a/frontend/src/hooks/team/useFetchTeam.ts
+++ b/frontend/src/hooks/team/useFetchTeam.ts
@@ -1,16 +1,16 @@
 import { useState, useEffect, useContext } from "react";
-import { TeamsShowResponse } from "../../types/teamTypes";
+import { FetchTeamResponse } from "../../types/teamTypes";
 import { AuthContext } from "../../providers/AuthProvider";
 import { teamApi } from "../../apis/team";
 
 export const useFetchTeam = (): [
-  TeamsShowResponse | undefined,
+  FetchTeamResponse | undefined,
   boolean,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   any | undefined
 ] => {
   const { currentUser, reloadTeamFlag } = useContext(AuthContext);
-  const [teamData, setTeamData] = useState<TeamsShowResponse>();
+  const [teamData, setTeamData] = useState<FetchTeamResponse>();
   const [isLoading, setIsLoading] = useState(true);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment
   const [error, setError] = useState<any>(null);
@@ -19,7 +19,7 @@ export const useFetchTeam = (): [
     if (!currentUser?.team_id) return undefined;
     const abortCtrl = new AbortController();
     teamApi
-      .getTeam<TeamsShowResponse>(currentUser.team_id)
+      .getTeam<FetchTeamResponse>(currentUser.team_id)
       .then((result) => {
         console.log(result);
         setTeamData(result);

--- a/frontend/src/hooks/team/useFetchTeams.ts
+++ b/frontend/src/hooks/team/useFetchTeams.ts
@@ -1,19 +1,19 @@
 import { useState, useEffect, useContext } from "react";
 import { useNavigate } from "react-router-dom";
-import { TeamsSelectResponse } from "../../types/teamTypes";
+import { TeamsResponse } from "../../types/teamTypes";
 import { teamApi } from "../../apis/team";
 import { SnackbarContext } from "../../providers/SnackbarProvider";
 
-export const useFetchTeams = (): [TeamsSelectResponse | undefined, boolean] => {
+export const useFetchTeams = (): [TeamsResponse | undefined, boolean] => {
   const { handleSetSnackbar } = useContext(SnackbarContext);
   const navigate = useNavigate();
-  const [teamsData, setTeamsData] = useState<TeamsSelectResponse>();
+  const [teamsData, setTeamsData] = useState<TeamsResponse>();
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     const abortCtrl = new AbortController();
     teamApi
-      .getTeams<TeamsSelectResponse>()
+      .getTeams<TeamsResponse>()
       .then((result) => {
         console.log(result);
         setTeamsData(result);

--- a/frontend/src/hooks/team/usePatchTeam.ts
+++ b/frontend/src/hooks/team/usePatchTeam.ts
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import Cookies from "js-cookie";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { baseAxios } from "../../apis/axios";
-import { TeamsResponse, EditTeam } from "../../types/teamTypes";
+import { TeamResponse, EditTeam } from "../../types/teamTypes";
 import { AuthContext } from "../../providers/AuthProvider";
 import { SnackbarContext } from "../../providers/SnackbarProvider";
 
@@ -31,7 +31,7 @@ export const usePatchTeam = (props: Props) => {
 
   const handleUpdateTeam = () => {
     baseAxios(options)
-      .then((res: AxiosResponse<TeamsResponse>) => {
+      .then((res: AxiosResponse<TeamResponse>) => {
         console.log(res);
         setReloadTeamFlag(!reloadTeamFlag);
         handleSetSnackbar({

--- a/frontend/src/hooks/team/usePostTeam.ts
+++ b/frontend/src/hooks/team/usePostTeam.ts
@@ -2,7 +2,7 @@ import { useContext } from "react";
 import { useNavigate } from "react-router-dom";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { baseAxios } from "../../apis/axios";
-import { TeamsResponse } from "../../types/teamTypes";
+import { TeamResponse } from "../../types/teamTypes";
 import { SnackbarContext } from "../../providers/SnackbarProvider";
 
 export const usePostTeam = (name: string) => {
@@ -17,7 +17,7 @@ export const usePostTeam = (name: string) => {
 
   const handleCreateTeam = () => {
     baseAxios(options)
-      .then((res: AxiosResponse<TeamsResponse>) => {
+      .then((res: AxiosResponse<TeamResponse>) => {
         console.log(res);
         handleSetSnackbar({
           open: true,

--- a/frontend/src/hooks/user/useFetchUser.ts
+++ b/frontend/src/hooks/user/useFetchUser.ts
@@ -1,17 +1,17 @@
 import { useState, useEffect, useContext } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { userApi } from "../../apis/user";
-import { UsersResponse } from "../../types/userTypes";
+import { UserResponse } from "../../types/userTypes";
 import { SnackbarContext } from "../../providers/SnackbarProvider";
 
 export const useFetchUser = (
   reloadFlag: boolean | undefined,
   action: string
-): [UsersResponse | undefined, boolean] => {
+): [UserResponse | undefined, boolean] => {
   const { handleSetSnackbar } = useContext(SnackbarContext);
   const { id: userId } = useParams();
   const navigate = useNavigate();
-  const [userData, setUserData] = useState<UsersResponse>();
+  const [userData, setUserData] = useState<UserResponse>();
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
@@ -20,7 +20,7 @@ export const useFetchUser = (
 
     if (action === "edit") {
       userApi
-        .editUser<UsersResponse>(userId)
+        .editUser<UserResponse>(userId)
         .then((result) => {
           console.log(result);
           setUserData(result);
@@ -41,7 +41,7 @@ export const useFetchUser = (
 
     if (action === "show") {
       userApi
-        .getUser<UsersResponse>(userId)
+        .getUser<UserResponse>(userId)
         .then((result) => {
           console.log(result);
           setUserData(result);

--- a/frontend/src/hooks/user/usePatchPassword.ts
+++ b/frontend/src/hooks/user/usePatchPassword.ts
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import Cookies from "js-cookie";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { baseAxios } from "../../apis/axios";
-import { AuthPasswordResponse } from "../../types/userTypes";
+import { PatchPasswordResponse } from "../../types/userTypes";
 import { AuthContext } from "../../providers/AuthProvider";
 import { SnackbarContext } from "../../providers/SnackbarProvider";
 
@@ -36,7 +36,7 @@ export const usePatchPassword = (props: Props) => {
 
   const handleUpdatePassword = () => {
     baseAxios(options)
-      .then((res: AxiosResponse<AuthPasswordResponse>) => {
+      .then((res: AxiosResponse<PatchPasswordResponse>) => {
         console.log(res);
         setCurrentUser(res.data.data);
         handleSetSnackbar({

--- a/frontend/src/hooks/user/usePatchUser.ts
+++ b/frontend/src/hooks/user/usePatchUser.ts
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import Cookies from "js-cookie";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { baseAxios } from "../../apis/axios";
-import { UsersUpdateResponse } from "../../types/userTypes";
+import { PatchAuthResponse } from "../../types/userTypes";
 import { AuthContext } from "../../providers/AuthProvider";
 import { SnackbarContext } from "../../providers/SnackbarProvider";
 
@@ -36,7 +36,7 @@ export const usePatchUser = (props: Props) => {
 
   const handleUpdateUser = () => {
     baseAxios(options)
-      .then((res: AxiosResponse<UsersUpdateResponse>) => {
+      .then((res: AxiosResponse<PatchAuthResponse>) => {
         console.log(res);
         setCurrentUser(res.data.data);
         handleSetSnackbar({

--- a/frontend/src/providers/AuthProvider.tsx
+++ b/frontend/src/providers/AuthProvider.tsx
@@ -10,7 +10,7 @@ import {
   useMemo,
   useState,
 } from "react";
-import { AuthSessionsResponse, User } from "../types/userTypes";
+import { FetchSessionsResponse, User } from "../types/userTypes";
 import { baseAxios } from "../apis/axios";
 
 type Props = {
@@ -73,7 +73,7 @@ export const AuthProvider: FC<Props> = ({ children }) => {
 
   useEffect(() => {
     baseAxios(options)
-      .then((res: AxiosResponse<AuthSessionsResponse>) => {
+      .then((res: AxiosResponse<FetchSessionsResponse>) => {
         console.log(res);
 
         if (res.data.is_signed_in === true) {

--- a/frontend/src/types/divisionTypes.ts
+++ b/frontend/src/types/divisionTypes.ts
@@ -11,7 +11,7 @@ export type Division = {
   comment: string;
 };
 
-export type DivisionHistory = {
+export type DividedHistory = {
   id: number;
   user_id: number | undefined;
   task_id: number;

--- a/frontend/src/types/taskTypes.ts
+++ b/frontend/src/types/taskTypes.ts
@@ -61,7 +61,7 @@ export type EditTask = {
   user_id: number;
 };
 
-export type DivisionTask = {
+export type DividedTask = {
   title: string;
   description: string;
   priority: string;

--- a/frontend/src/types/teamTypes.ts
+++ b/frontend/src/types/teamTypes.ts
@@ -13,15 +13,15 @@ export type EditTeam = {
   max_num_of_users: number;
 };
 
-export type TeamsSelectResponse = {
+export type TeamsResponse = {
   teams: Team[];
 };
 
-export type TeamsResponse = {
+export type TeamResponse = {
   team: Team;
 };
 
-export type TeamsShowResponse = {
+export type FetchTeamResponse = {
   team: Team;
   users: User[];
 };

--- a/frontend/src/types/userTypes.ts
+++ b/frontend/src/types/userTypes.ts
@@ -1,5 +1,5 @@
 /* eslint-disable import/no-cycle */
-import { DivisionHistory } from "./divisionTypes";
+import { DividedHistory } from "./divisionTypes";
 import { Task } from "./taskTypes";
 
 export type User = {
@@ -20,16 +20,25 @@ export type User = {
   admin: boolean;
 };
 
-export type UsersResponse = {
+export type UserResponse = {
   user: User;
   unfinished_tasks: Task[];
   finished_tasks: Task[];
-  divisions: DivisionHistory[];
+  divisions: DividedHistory[];
 };
 
-export type UsersUpdateResponse = {
+export type AuthResponse = {
+  data: User;
+};
+
+export type PatchAuthResponse = {
   status: string;
   data: User;
+};
+
+export type FetchSessionsResponse = {
+  is_signed_in: boolean;
+  current_user: User | undefined;
 };
 
 export type PasswordState = {
@@ -38,16 +47,7 @@ export type PasswordState = {
   showPassword: boolean;
 };
 
-export type AuthSessionsResponse = {
-  is_signed_in: boolean;
-  current_user: User | undefined;
-};
-
-export type AuthResponse = {
-  data: User;
-};
-
-export type AuthPasswordResponse = {
+export type PatchPasswordResponse = {
   success: boolean;
   data: User;
   message: string;


### PR DESCRIPTION
### 変更内容
**frontend**
- `/types`ディレクトリ下の型定義名をより分かりやすい名前に修正